### PR TITLE
Fix security level and label escaping

### DIFF
--- a/src/visualization/visualizationTemplate.ts
+++ b/src/visualization/visualizationTemplate.ts
@@ -290,7 +290,7 @@ export const VISUALIZATION_TEMPLATE = `<!DOCTYPE html>
             }
             mermaid.initialize({
                 startOnLoad: false,
-                securityLevel: 'loose',
+                securityLevel: 'strict',
                 theme: 'default',
                 fontSize: 14,
                 flowchart: {
@@ -325,7 +325,7 @@ export const VISUALIZATION_TEMPLATE = `<!DOCTYPE html>
                         const rankSpacing = 15;
                         mermaid.initialize({
                             startOnLoad: false,
-                            securityLevel: 'loose',
+                            securityLevel: 'strict',
                             theme: 'default',
                             fontSize: fontSize,
                             maxTextSize: 9000000,

--- a/src/visualization/visualizer.ts
+++ b/src/visualization/visualizer.ts
@@ -8,6 +8,18 @@ const panelGraphs = new WeakMap<vscode.WebviewPanel, ContractGraph>();
 // URI to the bundled Mermaid script
 let bundledMermaidUri: vscode.Uri | undefined;
 
+function escapeMermaidLabel(text: string): string {
+    return text
+        .replace(/"/g, "'")
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\*/g, '\\*')
+        .replace(/\+/g, '\\+')
+        .replace(/\-/g, '\\-')
+        .replace(/\[/g, '\\[')
+        .replace(/\]/g, '\\]');
+}
+
 export function createVisualizationPanel(
     context: vscode.ExtensionContext,
     graph: ContractGraph,
@@ -184,15 +196,7 @@ export function generateMermaidDiagram(graph: ContractGraph): string {
             let label = node.label.split('(')[0];
 
             // Escape any markdown characters in labels
-            label = label
-                .replace(/"/g, '\'')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;')
-                .replace(/\*/g, '\\*')
-                .replace(/\+/g, '\\+')
-                .replace(/\-/g, '\\-')
-                .replace(/\[/g, '\\[')
-                .replace(/\]/g, '\\]');
+            label = escapeMermaidLabel(label);
 
             // Use different node shapes based on function type
             if (node.type === 'entry') {
@@ -238,15 +242,7 @@ export function generateMermaidDiagram(graph: ContractGraph): string {
         }
 
         // Escape any markdown characters in labels
-        label = label
-            .replace(/"/g, '\'')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/\*/g, '\\*')
-            .replace(/\+/g, '\\+')
-            .replace(/\-/g, '\\-')
-            .replace(/\[/g, '\\[')
-            .replace(/\]/g, '\\]');
+        label = escapeMermaidLabel(label);
 
         // Check if this is a cross-cluster edge
         const fromCluster = nodeClusters.get(edge.from) || 0;


### PR DESCRIPTION
## Summary
- enforce `securityLevel: 'strict'` in Mermaid setup
- reuse a new `escapeMermaidLabel` helper for node and edge labels

## Testing
- `npx eslint -c .eslintrc.json src --ext ts` *(fails: Module needs an import attribute of type "json")*
- `npm test` *(fails to compile due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841b4443fdc832885ed12c55f320780