### PR TITLE
Replace console logs with OutputChannel

### DIFF
--- a/src/export/exportHandler.ts
+++ b/src/export/exportHandler.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { filterMermaidDiagram, generateVisualizationHtml } from '../visualization/templates';
+import { logError } from '../logger';
 
 // URI to the bundled Mermaid script
 let bundledMermaidUri: vscode.Uri | undefined;
@@ -48,7 +49,7 @@ export async function handleExport(
                 break;
         }
     } catch (error: any) {
-        console.error('Error handling export:', error);
+        logError('Error handling export', error);
         vscode.window.showErrorMessage(`Error handling export: ${error.message || String(error)}`);
         panel.webview.postMessage({
             command: 'saveResult',
@@ -82,7 +83,7 @@ async function handleApplyFilters(
         const originalGraph = response.content;
 
         if (!originalGraph) {
-            console.error('No original graph data received');
+            logError('No original graph data received');
             throw new Error('No original graph data received');
         }
 
@@ -113,11 +114,11 @@ async function handleApplyFilters(
                 nameFilter
             });
         } catch (updateError) {
-            console.error('Error updating webview content:', updateError);
+            logError('Error updating webview content', updateError);
             throw updateError;
         }
     } catch (error: any) {
-        console.error('Error applying filters:', error);
+        logError('Error applying filters', error);
         panel.webview.postMessage({
             command: 'filtersApplied',
             success: false,
@@ -270,7 +271,7 @@ async function handlePngExport(
 
             // Validate the data URL format
             if (!pngDataUrl.startsWith('data:image/png;base64,')) {
-                console.error('Invalid PNG data URL format:', pngDataUrl.substring(0, 50) + '...');
+                logError('Invalid PNG data URL format', pngDataUrl.substring(0, 50) + '...');
                 throw new Error('Invalid PNG data URL format');
             }
 
@@ -286,7 +287,7 @@ async function handlePngExport(
                 path: pngUri.fsPath
             });
         } catch (error: any) {
-            console.error('Error in PNG export:', error);
+            logError('Error in PNG export', error);
             vscode.window.showErrorMessage(`Failed to export PNG: ${error.message}`);
             throw error;
         }
@@ -342,7 +343,7 @@ async function handleJpgExport(
 
             // Validate the data URL format
             if (!jpgDataUrl.startsWith('data:image/jpeg;base64,')) {
-                console.error('Invalid JPG data URL format:', jpgDataUrl.substring(0, 50) + '...');
+                logError('Invalid JPG data URL format', jpgDataUrl.substring(0, 50) + '...');
                 throw new Error('Invalid JPG data URL format');
             }
 
@@ -358,9 +359,9 @@ async function handleJpgExport(
                 path: jpgUri.fsPath
             });
         } catch (error: any) {
-            console.error('Error in JPG export:', error);
+            logError('Error in JPG export', error);
             vscode.window.showErrorMessage(`Failed to export JPG: ${error.message}`);
             throw error;
         }
     }
-} 
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { createVisualizationPanel, generateMermaidDiagram } from './visualizatio
 import { handleExport } from './export/exportHandler';
 import { ContractGraph } from './types/graph';
 import { detectLanguage, parseContractByLanguage, getFunctionTypeFilters, parseContractWithImports } from './parser/parserUtils';
+import { logError } from './logger';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -57,7 +58,7 @@ export function activate(context: vscode.ExtensionContext) {
                 async (message) => {
                     if (message.command === 'applyFilters') {
                         if (!originalGraph) {
-                            console.error('Original graph data not available for filtering.');
+                            logError('Original graph data not available for filtering');
                             vscode.window.showErrorMessage('Cannot apply filters: original graph data is missing.');
                             return;
                         }
@@ -135,7 +136,7 @@ export function activate(context: vscode.ExtensionContext) {
                             });
 
                         } catch (filterError: any) {
-                            console.error('Error applying filters:', filterError);
+                            logError('Error applying filters', filterError);
                             vscode.window.showErrorMessage(`Error applying filters: ${filterError.message || String(filterError)}`);
                             // Send error message back to WebView
                             panel.webview.postMessage({
@@ -155,7 +156,7 @@ export function activate(context: vscode.ExtensionContext) {
 
             panel.reveal(vscode.ViewColumn.Beside);
         } catch (error: any) {
-            console.error('Error visualizing contract:', error);
+            logError('Error visualizing contract', error);
             vscode.window.showErrorMessage(`Error visualizing contract: ${error.message || String(error)}`);
             originalGraph = null; // Reset on error
         }
@@ -295,7 +296,7 @@ export function activate(context: vscode.ExtensionContext) {
                                 });
 
                             } catch (filterError: any) {
-                                console.error('Error applying filters:', filterError);
+                                logError('Error applying filters', filterError);
                                 vscode.window.showErrorMessage(`Error applying filters: ${filterError.message || String(filterError)}`);
                                 panel.webview.postMessage({
                                     command: 'filterError',
@@ -315,7 +316,7 @@ export function activate(context: vscode.ExtensionContext) {
                 panel.reveal(vscode.ViewColumn.Beside);
             });
         } catch (error: any) {
-            console.error('Error visualizing contract project:', error);
+            logError('Error visualizing contract project', error);
             vscode.window.showErrorMessage(`Error visualizing contract project: ${error.message || String(error)}`);
         }
     });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,9 @@
+import * as vscode from 'vscode';
+
+export const outputChannel = vscode.window.createOutputChannel('TON Graph');
+
+export function logError(message: string, err?: unknown): void {
+    const details = err ? (err instanceof Error ? err.message : String(err)) : '';
+    const formatted = details ? `${message}: ${details}` : message;
+    outputChannel.appendLine(formatted);
+}

--- a/src/parser/importHandler.ts
+++ b/src/parser/importHandler.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
+import { logError } from '../logger';
 
 /**
  * Processes import statements in FunC code (#include)
@@ -39,10 +40,10 @@ export async function processFuncImports(
                 importedCode.push(nestedImports.importedCode);
                 importedFilePaths.push(...nestedImports.importedFilePaths);
             } else {
-                console.warn(`Included file not found: ${fullPath}`);
+                logError(`Included file not found: ${fullPath}`);
             }
         } catch (error) {
-            console.error(`Error processing import ${fullPath}:`, error);
+            logError(`Error processing import ${fullPath}`, error);
         }
     }
 
@@ -85,7 +86,7 @@ export async function processTactImports(
                 fullPath = packagePath;
                 // Could further resolve subpaths here
             } else {
-                console.warn(`Package not found: ${packageName}`);
+                logError(`Package not found: ${packageName}`);
                 continue;
             }
         } else {
@@ -113,10 +114,10 @@ export async function processTactImports(
                 importedCode.push(nestedImports.importedCode);
                 importedFilePaths.push(...nestedImports.importedFilePaths);
             } else {
-                console.warn(`Imported file not found: ${fullPath}`);
+                logError(`Imported file not found: ${fullPath}`);
             }
         } catch (error) {
-            console.error(`Error processing import ${fullPath}:`, error);
+            logError(`Error processing import ${fullPath}`, error);
         }
     }
 
@@ -159,7 +160,7 @@ export async function processTolkImports(
                 fullPath = packagePath;
                 // Could further resolve subpaths here
             } else {
-                console.warn(`Package not found: ${packageName}`);
+                logError(`Package not found: ${packageName}`);
                 continue;
             }
         } else {
@@ -187,10 +188,10 @@ export async function processTolkImports(
                 importedCode.push(nestedImports.importedCode);
                 importedFilePaths.push(...nestedImports.importedFilePaths);
             } else {
-                console.warn(`Imported file not found: ${fullPath}`);
+                logError(`Imported file not found: ${fullPath}`);
             }
         } catch (error) {
-            console.error(`Error processing import ${fullPath}:`, error);
+            logError(`Error processing import ${fullPath}`, error);
         }
     }
 

--- a/src/visualization/templates.ts
+++ b/src/visualization/templates.ts
@@ -1,4 +1,5 @@
 export { generateVisualizationHtml } from "./htmlTemplate";
+import { logError } from '../logger';
 // generateErrorHtml remains useful for displaying initialization errors
 export function generateErrorHtml(message: string, mermaidScriptUri?: string): string {
     // Use error styles from "Copy"
@@ -406,7 +407,7 @@ export function filterMermaidDiagram(diagram: string, selectedTypes: string[], n
         const result = lines.join("\n");
         return validateAndFixDiagram(result);
     } catch (error) {
-        console.error("Error in filterMermaidDiagram:", error);
+        logError('Error in filterMermaidDiagram', error);
         return diagram;
     }
 }
@@ -457,7 +458,7 @@ function validateAndFixDiagram(diagramCode: string): string {
 
         return cleanedLines.join('\\n');
     } catch (error) {
-        console.error("Error in validateAndFixDiagram:", error);
+        logError('Error in validateAndFixDiagram', error);
         return diagramCode; // Return original on validation error
     }
 }

--- a/src/visualization/visualizer.ts
+++ b/src/visualization/visualizer.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { ContractGraph } from '../types/graph';
 import { generateVisualizationHtml, filterMermaidDiagram } from './templates';
+import { logError } from '../logger';
 
 // Map panels to their original graphs
 const panelGraphs = new WeakMap<vscode.WebviewPanel, ContractGraph>();
@@ -57,7 +58,7 @@ export function createVisualizationPanel(
         // Set the HTML content for the panel
         panel.webview.html = html;
     }).catch(error => {
-        console.error('Error loading Mermaid library:', error);
+        logError('Error loading Mermaid library', error);
         vscode.window.showErrorMessage(`Error loading Mermaid library: ${error.message}`);
     });
 
@@ -73,7 +74,7 @@ export function createVisualizationPanel(
                     // Handle other messages (export commands, etc.)
                 }
             } catch (error) {
-                console.error('Error handling message from webview:', error);
+                logError('Error handling message from webview', error);
                 panel.webview.postMessage({
                     command: 'filterError',
                     error: error instanceof Error ? error.message : String(error)
@@ -141,7 +142,7 @@ function handleFilterRequest(panel: vscode.WebviewPanel, selectedTypes: string[]
         });
 
     } catch (error) {
-        console.error('Error handling filter request:', error);
+        logError('Error handling filter request', error);
         panel.webview.postMessage({
             command: 'filterError',
             error: error instanceof Error ? error.message : String(error)


### PR DESCRIPTION
## Summary
- add `logger.ts` that defines `logError` and `outputChannel`
- log errors through the new OutputChannel in extension modules
- clean up console warnings/errors in import handler

## Testing
- `npm test` *(fails: Cannot find module 'vscode' or corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6841b564049883288f5e03f0bcc6ca71