### PR TITLE
Enable strict TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
                 "vscode": "^1.1.37"
             },
             "devDependencies": {
+                "@types/chai": "^5.2.2",
                 "@types/mocha": "^10.0.10",
+                "@types/mock-require": "^3.0.0",
                 "@types/node": "^14.x.x",
                 "@types/vscode": "^1.60.0",
                 "@typescript-eslint/eslint-plugin": "^4.x.x",
@@ -942,6 +944,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+            "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*"
+            }
+        },
         "node_modules/@types/d3": {
             "version": "7.4.3",
             "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -1195,6 +1207,13 @@
                 "@types/d3-selection": "*"
             }
         },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/geojson": {
             "version": "7946.0.16",
             "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -1212,6 +1231,13 @@
             "version": "10.0.10",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
             "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/mock-require": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@types/mock-require/-/mock-require-3.0.0.tgz",
+            "integrity": "sha512-TZ/s3ufaF+kEFPx9PqXKNd7OsPJoVsgOd59EA8XQLTRjJCsOdx5sEAOGhyrZ3Os78iaDKyGJWdQWyYWRg1Iyvg==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -121,7 +121,9 @@
         "test": "mocha -r ts-node/register test/**/*.test.ts"
     },
     "devDependencies": {
+        "@types/chai": "^5.2.2",
         "@types/mocha": "^10.0.10",
+        "@types/mock-require": "^3.0.0",
         "@types/node": "^14.x.x",
         "@types/vscode": "^1.60.0",
         "@typescript-eslint/eslint-plugin": "^4.x.x",

--- a/src/export/exportHandler.ts
+++ b/src/export/exportHandler.ts
@@ -133,7 +133,8 @@ async function handleApplyFilters(
  */
 async function getMermaidScriptUri(context: vscode.ExtensionContext, webview: vscode.Webview): Promise<string> {
     if (!bundledMermaidUri) {
-        bundledMermaidUri = vscode.Uri.joinPath(context.extensionUri, 'cached', 'mermaid.min.js');
+        const filePath = path.join(context.extensionPath, 'cached', 'mermaid.min.js');
+        bundledMermaidUri = vscode.Uri.file(filePath);
     }
     return webview.asWebviewUri(bundledMermaidUri).toString();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { createVisualizationPanel, generateMermaidDiagram } from './visualization/visualizer';
 import { handleExport } from './export/exportHandler';
 import { ContractGraph } from './types/graph';
@@ -8,7 +9,7 @@ import { logError } from './logger';
 export function activate(context: vscode.ExtensionContext) {
 
     // Create the cached directory for storing the Mermaid library
-    const cachedDir = vscode.Uri.joinPath(context.extensionUri, 'cached');
+    const cachedDir = vscode.Uri.file(path.join(context.extensionPath, 'cached'));
     try {
         vscode.workspace.fs.createDirectory(cachedDir);
     } catch (err) {

--- a/src/parser/tactParser.ts
+++ b/src/parser/tactParser.ts
@@ -482,14 +482,15 @@ export async function parseTactContract(code: string): Promise<ContractGraph> {
         let match: RegExpExecArray | null;
 
         while ((match = callRegex.exec(funcBody)) !== null) {
-            const baseCalledName = match[1];
+            const m = match as RegExpExecArray;
+            const baseCalledName = m[1];
             const targets = baseNameMap.get(baseCalledName) || [];
             targets.forEach(targetId => {
                 if (targetId !== funcName) {
-                    const lineStart = funcBody.lastIndexOf('\n', match.index) + 1;
-                    const lineEnd = funcBody.indexOf('\n', match.index);
+                    const lineStart = funcBody.lastIndexOf('\n', m.index) + 1;
+                    const lineEnd = funcBody.indexOf('\n', m.index);
                     const line = funcBody.substring(lineStart, lineEnd === -1 ? funcBody.length : lineEnd);
-                    const beforeMatch = line.substring(0, match.index - lineStart);
+                    const beforeMatch = line.substring(0, m.index - lineStart);
                     if (beforeMatch.includes('//') || beforeMatch.includes(';')) {
                         return;
                     }

--- a/src/visualization/visualizer.ts
+++ b/src/visualization/visualizer.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { ContractGraph } from '../types/graph';
 import { generateVisualizationHtml, filterMermaidDiagram } from './templates';
 import { logError } from '../logger';
@@ -36,7 +37,7 @@ export function createVisualizationPanel(
             enableScripts: true,
             retainContextWhenHidden: true,
             localResourceRoots: [
-                vscode.Uri.joinPath(context.extensionUri, 'cached')
+                vscode.Uri.file(path.join(context.extensionPath, 'cached'))
             ]
         }
     );
@@ -103,7 +104,8 @@ export function createVisualizationPanel(
  */
 async function getMermaidScriptUri(context: vscode.ExtensionContext, webview: vscode.Webview): Promise<string> {
     if (!bundledMermaidUri) {
-        bundledMermaidUri = vscode.Uri.joinPath(context.extensionUri, 'cached', 'mermaid.min.js');
+        const filePath = path.join(context.extensionPath, 'cached', 'mermaid.min.js');
+        bundledMermaidUri = vscode.Uri.file(filePath);
     }
     return webview.asWebviewUri(bundledMermaidUri).toString();
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,10 @@
         "outDir": "out",
         "rootDir": "src",
         "sourceMap": true,
-        "strict": false,
-        "noImplicitAny": false,
+        "strict": true,
+        "noImplicitAny": true,
+        "types": ["node", "vscode", "mocha"],
+        "skipLibCheck": true,
         "lib": [
             "es2018",
             "dom"


### PR DESCRIPTION
## Summary
- enable strict mode in `tsconfig.json`
- fix VS Code URI path handling without `joinPath`
- adjust regex match handling in `tactParser`
- add test type packages

## Testing
- `npx tsc -p ./`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841b89ba7d083288ac1e94fecbf0f6d