### PR TITLE
Implement global state caching for Toncenter API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@scaleton/tree-sitter-func": "^1.0.1",
                 "mermaid": "^11.6.0",
                 "moo": "^0.5.2",
+                "node-fetch": "^2.6.7",
                 "vscode": "^1.1.37",
                 "web-tree-sitter": "^0.25.6"
             },
@@ -5458,6 +5459,26 @@
             "license": "MIT",
             "optional": true
         },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/node-sarif-builder": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-2.0.3.tgz",
@@ -7005,6 +7026,12 @@
                 "node": ">=8.0"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+            "license": "MIT"
+        },
         "node_modules/ts-dedent": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -7661,6 +7688,12 @@
             "integrity": "sha512-WG+/YGbxw8r+rLlzzhV+OvgiOJCWdIpOucG3qBf3RCBFMkGDb1CanUi2BxCxjnkpzU3/hLWPT8VO5EKsMk9Fxg==",
             "license": "MIT"
         },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/whatwg-encoding": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -7682,6 +7715,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
         "@scaleton/tree-sitter-func": "^1.0.1",
         "mermaid": "^11.6.0",
         "moo": "^0.5.2",
+        "node-fetch": "^2.6.7",
         "vscode": "^1.1.37",
         "web-tree-sitter": "^0.25.6"
     },

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+
+interface CachedEntry<T> {
+    timestamp: number;
+    value: T;
+}
+
+const CACHE_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+
+export function getCacheKey(method: string, params: unknown): string {
+    return `${method}:${JSON.stringify(params)}`;
+}
+
+export async function getCachedResponse<T>(
+    context: vscode.ExtensionContext,
+    method: string,
+    params: unknown
+): Promise<T | undefined> {
+    const key = getCacheKey(method, params);
+    const entry = context.globalState.get<CachedEntry<T>>(key);
+    if (entry) {
+        const age = Date.now() - entry.timestamp;
+        if (age < CACHE_DURATION_MS) {
+            return entry.value;
+        }
+        await context.globalState.update(key, undefined);
+    }
+    return undefined;
+}
+
+export async function setCachedResponse<T>(
+    context: vscode.ExtensionContext,
+    method: string,
+    params: unknown,
+    value: T
+): Promise<void> {
+    const key = getCacheKey(method, params);
+    const entry: CachedEntry<T> = { timestamp: Date.now(), value };
+    await context.globalState.update(key, entry);
+}

--- a/src/api/toncenter.ts
+++ b/src/api/toncenter.ts
@@ -1,0 +1,25 @@
+import fetch from 'node-fetch';
+import * as vscode from 'vscode';
+import { getCachedResponse, setCachedResponse } from './cache';
+
+const BASE_URL = 'https://toncenter.com/api/v2/';
+
+export async function callToncenter<T>(
+    context: vscode.ExtensionContext,
+    method: string,
+    params: Record<string, unknown>
+): Promise<T> {
+    const cached = await getCachedResponse<T>(context, method, params);
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const search = new URLSearchParams({ ...params, method });
+    const res = await fetch(`${BASE_URL}?${search.toString()}`);
+    if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+    }
+    const data = (await res.json()) as T;
+    await setCachedResponse(context, method, params, data);
+    return data;
+}


### PR DESCRIPTION
## Summary
- add Toncenter API cache module
- add Toncenter API wrapper with caching
- include `node-fetch` dependency

## Testing
- `npm run lint` *(fails: numerous pre-existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841bf670b488328a77e677ca9146052