### PR TITLE
Add workspace path validation for imports

### DIFF
--- a/test/importHandler.test.ts
+++ b/test/importHandler.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+import * as path from 'path';
+
+const testRoot = __dirname;
+mock('vscode', {
+    window: { createOutputChannel: () => ({ appendLine: () => {} }) },
+    workspace: { workspaceFolders: [{ uri: { fsPath: testRoot } }] }
+});
+
+import { processFuncImports } from '../src/parser/importHandler';
+
+describe('ImportHandler', () => {
+    it('rejects imports outside workspace', async () => {
+        const code = '#include "../../etc/passwd"';
+        const result = await processFuncImports(code, path.join(testRoot, 'dummy.fc'));
+        expect(result.importedFilePaths.length).to.equal(0);
+    });
+});


### PR DESCRIPTION
## Summary
- ensure Func/Tact/Tolk imports stay within workspace
- log an error when import paths escape the workspace
- test that attempting to import '../../etc/passwd' is rejected

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841c2c79b3083289455c53b70b166fd