### PR TITLE
Add API key management command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 2. Go to Extensions view (Ctrl+Shift+X)
 3. Search for "TON Graph"
 4. Click Install
+5. Run "TON Graph: Set API Key" from the command palette and enter your Toncenter API key
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "activationEvents": [
         "onCommand:ton-graph.visualize",
         "onCommand:ton-graph.visualizeProject",
+        "onCommand:ton-graph.setApiKey",
         "onLanguage:func",
         "onLanguage:tact",
         "onLanguage:tolk"
@@ -84,6 +85,10 @@
             {
                 "command": "ton-graph.saveJpg",
                 "title": "TON Graph: Save JPG Diagram"
+            },
+            {
+                "command": "ton-graph.setApiKey",
+                "title": "TON Graph: Set API Key"
             }
         ],
         "menus": {

--- a/src/api/toncenter.ts
+++ b/src/api/toncenter.ts
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import * as vscode from 'vscode';
 import { getCachedResponse, setCachedResponse } from './cache';
+import { getApiKey } from '../secrets/tokenManager';
 
 const BASE_URL = 'https://toncenter.com/api/v2/';
 
@@ -9,17 +10,19 @@ export async function callToncenter<T>(
     method: string,
     params: Record<string, unknown>
 ): Promise<T> {
-    const cached = await getCachedResponse<T>(context, method, params);
+    const apiKey = await getApiKey(context);
+    const paramsWithKey = apiKey ? { ...params, api_key: apiKey } : { ...params };
+    const cached = await getCachedResponse<T>(context, method, paramsWithKey);
     if (cached !== undefined) {
         return cached;
     }
 
-    const search = new URLSearchParams({ ...params, method });
+    const search = new URLSearchParams({ ...paramsWithKey, method });
     const res = await fetch(`${BASE_URL}?${search.toString()}`);
     if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
     }
     const data = (await res.json()) as T;
-    await setCachedResponse(context, method, params, data);
+    await setCachedResponse(context, method, paramsWithKey, data);
     return data;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { handleExport } from './export/exportHandler';
 import { ContractGraph } from './types/graph';
 import { detectLanguage, parseContractByLanguage, getFunctionTypeFilters, parseContractWithImports } from './parser/parserUtils';
 import { logError } from './logger';
+import { setApiKey } from './secrets/tokenManager';
 
 let panel: vscode.WebviewPanel | undefined;
 
@@ -343,6 +344,19 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     context.subscriptions.push(projectDisposable);
+
+    const apiKeyDisposable = vscode.commands.registerCommand('ton-graph.setApiKey', async () => {
+        const value = await vscode.window.showInputBox({
+            prompt: 'Enter TON API key',
+            ignoreFocusOut: true,
+        });
+        if (value !== undefined) {
+            await setApiKey(context, value.trim());
+            vscode.window.showInformationMessage('TON Graph API key saved');
+        }
+    });
+
+    context.subscriptions.push(apiKeyDisposable);
 }
 
 export function deactivate() { }

--- a/src/secrets/tokenManager.ts
+++ b/src/secrets/tokenManager.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode';
+
+const SECRET_KEY = 'toncenterApiKey';
+
+export async function getApiKey(context: vscode.ExtensionContext): Promise<string | undefined> {
+    return context.secrets.get(SECRET_KEY);
+}
+
+export async function setApiKey(context: vscode.ExtensionContext, apiKey: string): Promise<void> {
+    await context.secrets.store(SECRET_KEY, apiKey);
+}
+
+export async function deleteApiKey(context: vscode.ExtensionContext): Promise<void> {
+    await context.secrets.delete(SECRET_KEY);
+}


### PR DESCRIPTION
## Summary
- add tokenManager service for handling secrets
- update Toncenter API calls to use saved key
- add `ton-graph.setApiKey` command
- document API key setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c3bfbb24832890f82d171069c05d