### PR TITLE
Update parsers to use ContractNode type

### DIFF
--- a/src/parser/funcParser.ts
+++ b/src/parser/funcParser.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as WebTreeSitter from 'web-tree-sitter';
 import { loadFunC } from '@scaleton/tree-sitter-func';
-import { ContractGraph, GraphNode } from '../types/graph';
+import { ContractGraph, ContractNode } from '../types/graph';
 
 const BUILT_IN_FUNCTIONS = new Set([
     'if', 'elseif', 'while', 'for', 'switch', 'return', 'throw', 'throw_unless',
@@ -64,7 +64,7 @@ export async function parseContractCode(code: string): Promise<ContractGraph> {
         const bodyNode = fn.descendantsOfType('block_statement')[0];
         if (bodyNode) bodies.set(funcName, bodyNode);
 
-        const node: GraphNode = {
+        const node: ContractNode = {
             id: funcName,
             label: `${funcName}(${params})`,
             type: 'function',

--- a/src/parser/tactParser.ts
+++ b/src/parser/tactParser.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as moo from 'moo';
-import { ContractGraph, GraphNode } from '../types/graph';
+import { ContractGraph, ContractNode } from '../types/graph';
 
 const lexer = moo.compile({
     ws: /[ \t\r]+/,
@@ -88,7 +88,7 @@ export async function parseTactContract(code: string): Promise<ContractGraph> {
             const params = tokens.slice(paramsStart, paramsEnd).map(t => t.value).join('');
             const bodyText = tokens.slice(bodyStart, bodyEnd).map(t => t.value).join('');
             functions.set(name, { body: bodyText, params });
-            const node: GraphNode = {
+            const node: ContractNode = {
                 id: name,
                 label: `${name}(${params})`,
                 type: 'function',

--- a/src/parser/tolkParser.ts
+++ b/src/parser/tolkParser.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ContractGraph, GraphNode } from '../types/graph';
+import { ContractGraph, ContractNode } from '../types/graph';
 
 // List of built-in functions to exclude
 const BUILT_IN_FUNCTIONS = new Set([
@@ -179,7 +179,7 @@ export async function parseTolkContract(code: string): Promise<ContractGraph> {
 
     // Create nodes for each function
     functions.forEach((func, name) => {
-        const node: GraphNode = {
+        const node: ContractNode = {
             id: name,
             label: `${name}(${func.params})`,
             type: 'function',

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -9,6 +9,8 @@ export interface GraphNode {
     traitName?: string;
 }
 
+export type ContractNode = GraphNode;
+
 export interface GraphEdge {
     from: string;
     to: string;


### PR DESCRIPTION
## Summary
- define `ContractNode` alias for `GraphNode`
- switch parsers to `ContractNode`

## Testing
- `npm run compile`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841c6e6409c8328aedd93d3597870d8