### PR TITLE
Add devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "name": "TON Graph Dev Container",
+    "image": "mcr.microsoft.com/devcontainers/node:18-bullseye",
+    "postCreateCommand": "npm ci && npx playwright install --with-deps chromium"
+}

--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ chmod +x rebuild.sh && ./rebuild.sh
 # The Mermaid library is bundled locally, so the build works offline
 ```
 
+### Developing with Dev Containers
+
+A Dev Container configuration is provided in `.devcontainer`.
+To work with it:
+
+1. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for VS Code.
+2. Run **Remote-Containers: Open Folder in Container...** from the command palette and select this repository.
+3. Wait for the container to build and dependencies to install.
+4. You can now run `npm test` or other tasks inside the container.
+
 ## Requirements
 
 - Visual Studio Code 1.60.0 or newer


### PR DESCRIPTION
## Summary
- add devcontainer based on Node 18 with Chromium for Playwright
- document how to open the project in a dev container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841ca0d00548328a77c91b75d8a112e