### PR TITLE
Add Playwright E2E test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,22 @@
+name: playwright
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install dependencies
+        run: npm ci
+      - name: Install browsers
+        run: npx playwright install --with-deps
+      - name: Run tests
+        run: xvfb-run -a npm run test:playwright

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "winston": "^3.17.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "@types/chai": "^5.2.2",
         "@types/mocha": "^10.0.10",
         "@types/mock-require": "^3.0.0",
@@ -1594,6 +1595,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@scaleton/tree-sitter-func": {
@@ -8368,6 +8385,53 @@
         "confbox": "^0.2.1",
         "exsolve": "^1.0.1",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,8 @@
     "watch": "tsc -watch -p ./",
     "lint": "eslint src --ext ts",
     "test": "nyc mocha -r ts-node/register test/**/*.test.ts",
-    "build:webview": "ts-node scripts/build-webview.ts"
+    "build:webview": "ts-node scripts/build-webview.ts",
+    "test:playwright": "playwright test"
   },
   "lint-staged": {
     "*.{ts,js}": [
@@ -134,6 +135,7 @@
     "*.{json,md}": "prettier --check"
   },
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "@types/chai": "^5.2.2",
     "@types/mocha": "^10.0.10",
     "@types/mock-require": "^3.0.0",
@@ -151,10 +153,10 @@
     "lint-staged": "^14.0.1",
     "mocha": "^10.0.0",
     "mock-require": "^3.0.3",
+    "nyc": "^15.1.0",
     "terser": "^5.41.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.x.x",
-    "nyc": "^15.1.0"
+    "typescript": "^4.x.x"
   },
   "dependencies": {
     "@scaleton/tree-sitter-func": "^1.0.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  testDir: './playwright',
+  timeout: 60000,
+});

--- a/playwright/verifyWebview.js
+++ b/playwright/verifyWebview.js
@@ -1,0 +1,31 @@
+const vscode = require('vscode');
+const path = require('path');
+
+module.exports = async function () {
+  const ext = vscode.extensions.getExtension('positiveweb3.ton-graph');
+  if (ext) {
+    await ext.activate();
+  }
+
+  const panelStub = {
+    webview: {
+      html: '',
+      asWebviewUri: (uri) => uri,
+      onDidReceiveMessage: () => {},
+      postMessage: () => Promise.resolve(true)
+    },
+    onDidDispose: () => {}
+  };
+
+  const originalCreate = vscode.window.createWebviewPanel;
+  vscode.window.createWebviewPanel = () => panelStub;
+
+  const samplePath = path.join(__dirname, '..', 'examples', 'func_nominators.fc');
+  await vscode.commands.executeCommand('ton-graph.visualize', vscode.Uri.file(samplePath));
+
+  if (!panelStub.webview.html.includes('.mermaid')) {
+    throw new Error('Mermaid script not found in webview');
+  }
+
+  vscode.window.createWebviewPanel = originalCreate;
+};

--- a/playwright/webview.test.ts
+++ b/playwright/webview.test.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { runTests } from 'vscode-test';
+import * as path from 'path';
+
+test('webview contains mermaid', async () => {
+  const extensionDevelopmentPath = path.resolve(__dirname, '..');
+  const extensionTestsPath = path.resolve(__dirname, 'verifyWebview.js');
+
+  const exitCode = await runTests({
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    launchArgs: [
+      '--disable-extensions',
+      '--no-sandbox',
+      '--disable-gpu',
+      '--disable-dev-shm-usage',
+      '--skip-release-notes',
+      '--skip-welcome'
+    ]
+  });
+
+  expect(exitCode).toBeUndefined();
+});


### PR DESCRIPTION
## Summary
- install Playwright
- add Playwright test that launches the extension via `vscode-test` and verifies that the webview HTML includes `.mermaid`
- run Playwright in CI using GitHub Actions

## Testing
- `npm test`
- `xvfb-run -a npm run test:playwright` *(fails: Failed to connect to the bus)*

------
https://chatgpt.com/codex/tasks/task_e_6841ce1614c08328b7e8453b98984048