### PR TITLE
Add cross-platform CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: ci
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [18, 20]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Package extension
+        run: npx vsce package


### PR DESCRIPTION
## Summary
- add CI workflow that runs tests and packages the VSCode extension on ubuntu, windows, and macos with Node 18 and 20

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841d0f449388328acdea02a9b3dab9c