### PR TITLE
Add production pruning step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "mermaid": "^11.6.0",
         "moo": "^0.5.2",
         "node-fetch": "^2.6.7",
-        "vscode": "^1.1.37",
         "web-tree-sitter": "^0.25.6",
         "winston": "^3.17.0"
       },
@@ -28,7 +27,7 @@
         "@types/vscode": "^1.60.0",
         "@typescript-eslint/eslint-plugin": "^4.x.x",
         "@typescript-eslint/parser": "^4.x.x",
-        "@vscode/vsce": "^3.3.2",
+        "@vscode/vsce": "^3.5.0",
         "chai": "^4.3.0",
         "esbuild": "^0.19.12",
         "eslint": "^7.x.x",
@@ -39,7 +38,8 @@
         "nyc": "^15.1.0",
         "terser": "^5.41.0",
         "ts-node": "^10.9.1",
-        "typescript": "^4.x.x"
+        "typescript": "^4.x.x",
+        "vscode": "^1.1.37"
       },
       "engines": {
         "vscode": "^1.60.0"

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@types/vscode": "^1.60.0",
     "@typescript-eslint/eslint-plugin": "^4.x.x",
     "@typescript-eslint/parser": "^4.x.x",
-    "@vscode/vsce": "^3.3.2",
+    "@vscode/vsce": "^3.5.0",
     "chai": "^4.3.0",
     "esbuild": "^0.19.12",
     "eslint": "^7.x.x",
@@ -156,14 +156,14 @@
     "nyc": "^15.1.0",
     "terser": "^5.41.0",
     "ts-node": "^10.9.1",
-    "typescript": "^4.x.x"
+    "typescript": "^4.x.x",
+    "vscode": "^1.1.37"
   },
   "dependencies": {
     "@scaleton/tree-sitter-func": "^1.0.1",
     "mermaid": "^11.6.0",
     "moo": "^0.5.2",
     "node-fetch": "^2.6.7",
-    "vscode": "^1.1.37",
     "web-tree-sitter": "^0.25.6",
     "winston": "^3.17.0"
   },

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -8,6 +8,9 @@ rm -rf ./out
 # Install dependencies using the lockfile
 npm ci
 
+# Remove dev dependencies
+npm prune --production
+
 # Install vsce locally
 npm install -D @vscode/vsce
 


### PR DESCRIPTION
## Summary
- prune dev dependencies during rebuild
- move `vscode` to dev dependencies and update `vsce` version

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841d329f900832895d622732d5fc03f