### PR TITLE
Add CSP meta tag to visualization panel

### DIFF
--- a/src/visualization/htmlTemplate.ts
+++ b/src/visualization/htmlTemplate.ts
@@ -7,7 +7,8 @@ export function generateVisualizationHtml(
     webviewScriptUri: string
 ): string {
     const filtersJson = JSON.stringify(functionTypeFilters);
-    return VISUALIZATION_TEMPLATE
+    const cspMetaTag = '<meta http-equiv="Content-Security-Policy" content="default-src \'self\' vscode-resource:; script-src \'self\' vscode-resource:; style-src \'self\' vscode-resource:; img-src \'self\' vscode-resource:;">';
+    return VISUALIZATION_TEMPLATE.replace('<head>', `<head>${cspMetaTag}`)
         .replace('{{MERMAID_DIAGRAM}}', mermaidDiagram)
         .replace('{{MERMAID_SCRIPT_URI}}', mermaidScriptUri)
         .replace('{{FILTERS_JSON}}', filtersJson)

--- a/test/visualizer.test.ts
+++ b/test/visualizer.test.ts
@@ -110,5 +110,19 @@ describe('Visualizer', () => {
             await new Promise(resolve => setTimeout(resolve, 0));
             expect(panel.webview.html).to.include('graph TB;');
         });
+
+        it('injects a CSP meta tag', async () => {
+            const context = { extensionPath: process.cwd(), subscriptions: [] } as any;
+            const graph: ContractGraph = {
+                nodes: [
+                    { id: 'n', label: 'n()', type: 'entry', contractName: '' }
+                ],
+                edges: []
+            };
+
+            const panel = createVisualizationPanel(context, graph, []);
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(panel.webview.html).to.include('Content-Security-Policy');
+        });
     });
 });


### PR DESCRIPTION
## Summary
- add a content security policy meta tag to the visualization HTML
- test that generated webview HTML includes the CSP tag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841db496c688328996972a395c47371