### PR TITLE
Add log rotation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,11 @@ To work with it:
 3. Wait for the container to build and dependencies to install.
 4. You can now run `npm test` or other tasks inside the container.
 
+### Logs
+
+Runtime logs are written to `logs/extension.log` in the project root. The file
+rotates when it reaches 1 MB and up to five log files are kept.
+
 ## Requirements
 
 - Visual Studio Code 1.60.0 or newer

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -12,7 +12,11 @@ const logger = createLogger({
   format: format.json(),
   transports: [
     new transports.Console({ format: format.json() }),
-    new transports.File({ filename: path.join(logsDir, 'extension.log') })
+    new transports.File({
+      filename: path.join(logsDir, 'extension.log'),
+      maxsize: 1024 * 1024,
+      maxFiles: 5
+    })
   ]
 });
 

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import logger from '../src/logging/logger';
+import { transports as winstonTransports } from 'winston';
+
+describe('Logger', () => {
+  it('configures file rotation', () => {
+    const fileTransport = logger.transports.find(t => t instanceof winstonTransports.File);
+    expect(fileTransport).to.exist;
+    expect((fileTransport as any).maxsize).to.equal(1024 * 1024);
+    expect((fileTransport as any).maxFiles).to.equal(5);
+  });
+});


### PR DESCRIPTION
## Summary
- enable file log rotation
- document where logs are written
- test logger configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841dd78d88c83289c3b9a2cb2a73073