### PR TITLE
Implement LRU caching and tests

### DIFF
--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -5,7 +5,9 @@ interface CachedEntry<T> {
     value: T;
 }
 
-const CACHE_DURATION_MS = 5 * 60 * 1000; // 5 minutes
+const CACHE_DURATION_MS = 10 * 60 * 1000; // 10 minutes
+const MAX_ENTRIES = 100;
+const CACHE_STATE_KEY = 'tonGraphCache';
 
 export function getCacheKey(method: string, params: unknown): string {
     return `${method}:${JSON.stringify(params)}`;
@@ -17,13 +19,25 @@ export async function getCachedResponse<T>(
     params: unknown
 ): Promise<T | undefined> {
     const key = getCacheKey(method, params);
-    const entry = context.globalState.get<CachedEntry<T>>(key);
+    const state = context.workspaceState.get<{ entries: Record<string, CachedEntry<unknown>>; order: string[] }>(CACHE_STATE_KEY, { entries: {}, order: [] });
+    const entry = state.entries[key] as CachedEntry<T> | undefined;
     if (entry) {
         const age = Date.now() - entry.timestamp;
         if (age < CACHE_DURATION_MS) {
+            const idx = state.order.indexOf(key);
+            if (idx !== -1) {
+                state.order.splice(idx, 1);
+                state.order.push(key);
+            }
+            await context.workspaceState.update(CACHE_STATE_KEY, state);
             return entry.value;
         }
-        await context.globalState.update(key, undefined);
+        delete state.entries[key];
+        const idx = state.order.indexOf(key);
+        if (idx !== -1) {
+            state.order.splice(idx, 1);
+        }
+        await context.workspaceState.update(CACHE_STATE_KEY, state);
     }
     return undefined;
 }
@@ -35,6 +49,18 @@ export async function setCachedResponse<T>(
     value: T
 ): Promise<void> {
     const key = getCacheKey(method, params);
-    const entry: CachedEntry<T> = { timestamp: Date.now(), value };
-    await context.globalState.update(key, entry);
+    const state = context.workspaceState.get<{ entries: Record<string, CachedEntry<unknown>>; order: string[] }>(CACHE_STATE_KEY, { entries: {}, order: [] });
+    state.entries[key] = { timestamp: Date.now(), value };
+    const existing = state.order.indexOf(key);
+    if (existing !== -1) {
+        state.order.splice(existing, 1);
+    }
+    state.order.push(key);
+    while (state.order.length > MAX_ENTRIES) {
+        const oldest = state.order.shift();
+        if (oldest) {
+            delete state.entries[oldest];
+        }
+    }
+    await context.workspaceState.update(CACHE_STATE_KEY, state);
 }

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', {});
+import { getCachedResponse, setCachedResponse, getCacheKey } from '../src/api/cache';
+
+class TestMemento {
+    private store: Record<string, any> = {};
+    get<T>(key: string, defaultValue?: T): T {
+        if (key in this.store) {
+            return this.store[key];
+        }
+        return defaultValue as T;
+    }
+    async update(key: string, value: any): Promise<void> {
+        if (value === undefined) {
+            delete this.store[key];
+        } else {
+            this.store[key] = value;
+        }
+    }
+}
+
+describe('Cache', () => {
+    let context: { workspaceState: TestMemento };
+
+    beforeEach(() => {
+        context = { workspaceState: new TestMemento() } as any;
+    });
+
+    it('stores and retrieves values', async () => {
+        await setCachedResponse(context as any, 'm1', { a: 1 }, 123);
+        const value = await getCachedResponse<number>(context as any, 'm1', { a: 1 });
+        expect(value).to.equal(123);
+    });
+
+    it('expires entries after ttl', async () => {
+        await setCachedResponse(context as any, 'm2', {}, 'v');
+        const state = context.workspaceState.get<any>('tonGraphCache');
+        const key = getCacheKey('m2', {});
+        state.entries[key].timestamp = Date.now() - (10 * 60 * 1000 + 1);
+        await context.workspaceState.update('tonGraphCache', state);
+        const value = await getCachedResponse(context as any, 'm2', {});
+        expect(value).to.be.undefined;
+        const newState = context.workspaceState.get<any>('tonGraphCache');
+        expect(newState.entries[key]).to.be.undefined;
+    });
+
+    it('evicts least recently used entries when limit exceeded', async () => {
+        for (let i = 0; i < 101; i++) {
+            await setCachedResponse(context as any, 'm', { i }, i);
+        }
+        const state = context.workspaceState.get<any>('tonGraphCache');
+        expect(state.order.length).to.equal(100);
+        const removedKey = getCacheKey('m', { i: 0 });
+        expect(state.entries[removedKey]).to.be.undefined;
+        const lastKey = getCacheKey('m', { i: 100 });
+        expect(state.entries[lastKey].value).to.equal(100);
+    });
+});


### PR DESCRIPTION
## Summary
- use ExtensionContext.workspaceState for caching
- add LRU cache with 100 entries, 10 minute TTL
- test cache insertion, retrieval, expiration and eviction

## Testing
- `npm run compile`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841de97806083288823e165c7c1f06f