### PR TITLE
Use GraphNodeKind enum

### DIFF
--- a/src/parser/funcParser.ts
+++ b/src/parser/funcParser.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import * as WebTreeSitter from 'web-tree-sitter';
 import { loadFunC } from '@scaleton/tree-sitter-func';
 import { ContractGraph, ContractNode } from '../types/graph';
+import { GraphNodeKind } from '../types/graphNodeKind';
 
 const BUILT_IN_FUNCTIONS = new Set([
     'if', 'elseif', 'while', 'for', 'switch', 'return', 'throw', 'throw_unless',
@@ -67,7 +68,7 @@ export async function parseContractCode(code: string): Promise<ContractGraph> {
         const node: ContractNode = {
             id: funcName,
             label: `${funcName}(${params})`,
-            type: 'function',
+            type: GraphNodeKind.Function,
             contractName,
             parameters: params.split(',').map((p: string) => p.trim()).filter(Boolean),
             functionType: 'regular'

--- a/src/parser/tactParser.ts
+++ b/src/parser/tactParser.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as moo from 'moo';
 import { ContractGraph, ContractNode } from '../types/graph';
+import { GraphNodeKind } from '../types/graphNodeKind';
 
 const lexer = moo.compile({
     ws: /[ \t\r]+/,
@@ -91,7 +92,7 @@ export async function parseTactContract(code: string): Promise<ContractGraph> {
             const node: ContractNode = {
                 id: name,
                 label: `${name}(${params})`,
-                type: 'function',
+                type: GraphNodeKind.Function,
                 contractName,
                 parameters: params.split(',').map((p: string) => p.trim()).filter(Boolean),
                 functionType: kind

--- a/src/parser/tolkParser.ts
+++ b/src/parser/tolkParser.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { ContractGraph, ContractNode } from '../types/graph';
+import { GraphNodeKind } from '../types/graphNodeKind';
 
 // List of built-in functions to exclude
 const BUILT_IN_FUNCTIONS = new Set([
@@ -182,7 +183,7 @@ export async function parseTolkContract(code: string): Promise<ContractGraph> {
         const node: ContractNode = {
             id: name,
             label: `${name}(${func.params})`,
-            type: 'function',
+            type: GraphNodeKind.Function,
             contractName,
             parameters: func.params.split(',').map(p => p.trim()).filter(p => p),
             functionType: func.type as any

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -1,7 +1,9 @@
+import { GraphNodeKind } from './graphNodeKind';
+
 export interface GraphNode {
     id: string;
     label: string;
-    type: string;
+    type: GraphNodeKind;
     contractName: string;
     parameters?: string[];
     functionType?: string;

--- a/src/types/graphNodeKind.ts
+++ b/src/types/graphNodeKind.ts
@@ -1,0 +1,7 @@
+export enum GraphNodeKind {
+    Entry = 'entry',
+    Internal = 'internal',
+    External = 'external',
+    Function = 'function',
+}
+

--- a/src/visualization/visualizer.ts
+++ b/src/visualization/visualizer.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { ContractGraph } from '../types/graph';
+import { GraphNodeKind } from '../types/graphNodeKind';
 import { generateVisualizationHtml, filterMermaidDiagram } from './templates';
 import { logError } from '../logger';
 
@@ -211,9 +212,9 @@ export function generateMermaidDiagram(graph: ContractGraph): string {
             label = escapeMermaidLabel(label);
 
             // Use different node shapes based on function type
-            if (node.type === 'entry') {
+            if (node.type === GraphNodeKind.Entry) {
                 diagram += `        ${nodeId}(["${label}"])\n`;
-            } else if (node.type === 'external') {
+            } else if (node.type === GraphNodeKind.External) {
                 diagram += `        ${nodeId}[["${label}"]]\n`;
             } else {
                 diagram += `        ${nodeId}["${label}"]\n`;

--- a/test/visualizer.test.ts
+++ b/test/visualizer.test.ts
@@ -22,18 +22,19 @@ mock('vscode', {
 
 import { generateMermaidDiagram, clusterNodes, createVisualizationPanel } from '../src/visualization/visualizer';
 import { ContractGraph } from '../src/types/graph';
+import { GraphNodeKind } from '../src/types/graphNodeKind';
 
 describe('Visualizer', () => {
     describe('clusterNodes', () => {
         it('groups isolated and connected nodes into clusters', () => {
             const graph: ContractGraph = {
                 nodes: [
-                    { id: 'a', label: 'a()', type: 'internal', contractName: '' },
-                    { id: 'b', label: 'b()', type: 'internal', contractName: '' },
-                    { id: 'c', label: 'c()', type: 'internal', contractName: '' },
-                    { id: 'd', label: 'd()', type: 'internal', contractName: '' },
-                    { id: 'e', label: 'e()', type: 'internal', contractName: '' },
-                    { id: 'f', label: 'f()', type: 'internal', contractName: '' },
+                    { id: 'a', label: 'a()', type: GraphNodeKind.Internal, contractName: '' },
+                    { id: 'b', label: 'b()', type: GraphNodeKind.Internal, contractName: '' },
+                    { id: 'c', label: 'c()', type: GraphNodeKind.Internal, contractName: '' },
+                    { id: 'd', label: 'd()', type: GraphNodeKind.Internal, contractName: '' },
+                    { id: 'e', label: 'e()', type: GraphNodeKind.Internal, contractName: '' },
+                    { id: 'f', label: 'f()', type: GraphNodeKind.Internal, contractName: '' },
                 ],
                 edges: [
                     { from: 'a', to: 'b', label: '' },
@@ -57,9 +58,9 @@ describe('Visualizer', () => {
         it('creates a mermaid diagram with nodes and edges', () => {
             const graph: ContractGraph = {
                 nodes: [
-                    { id: 'start', label: 'start()', type: 'entry', contractName: '' },
-                    { id: 'foo', label: 'foo()', type: 'internal', contractName: '' },
-                    { id: 'bar', label: 'bar()', type: 'external', contractName: '' },
+                    { id: 'start', label: 'start()', type: GraphNodeKind.Entry, contractName: '' },
+                    { id: 'foo', label: 'foo()', type: GraphNodeKind.Internal, contractName: '' },
+                    { id: 'bar', label: 'bar()', type: GraphNodeKind.External, contractName: '' },
                 ],
                 edges: [
                     { from: 'start', to: 'foo', label: '' },
@@ -80,9 +81,9 @@ describe('Visualizer', () => {
         it('filters parameter comments in edge labels', () => {
             const graph: ContractGraph = {
                 nodes: [
-                    { id: 'start', label: 'start()', type: 'entry', contractName: '' },
+                    { id: 'start', label: 'start()', type: GraphNodeKind.Entry, contractName: '' },
                     {
-                        id: 'foo', label: 'foo()', type: 'internal', contractName: '',
+                        id: 'foo', label: 'foo()', type: GraphNodeKind.Internal, contractName: '',
                         parameters: ['int a', ';; ignore', '// comment', 'int b // trailing']
                     }
                 ],
@@ -101,7 +102,7 @@ describe('Visualizer', () => {
             const context = { extensionPath: process.cwd(), subscriptions: [] } as any;
             const graph: ContractGraph = {
                 nodes: [
-                    { id: 'n', label: 'n()', type: 'entry', contractName: '' }
+                    { id: 'n', label: 'n()', type: GraphNodeKind.Entry, contractName: '' }
                 ],
                 edges: []
             };
@@ -115,7 +116,7 @@ describe('Visualizer', () => {
             const context = { extensionPath: process.cwd(), subscriptions: [] } as any;
             const graph: ContractGraph = {
                 nodes: [
-                    { id: 'n', label: 'n()', type: 'entry', contractName: '' }
+                    { id: 'n', label: 'n()', type: GraphNodeKind.Entry, contractName: '' }
                 ],
                 edges: []
             };


### PR DESCRIPTION
## Summary
- create `GraphNodeKind` enum
- use enum in graph types and parsers
- update visualization to rely on enum values
- adjust tests to the enum

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841e1c0c97883288a54f345bbd610d3