### PR TITLE
Add async mermaid loading and loading overlay

### DIFF
--- a/src/export/exportHandler.ts
+++ b/src/export/exportHandler.ts
@@ -136,6 +136,12 @@ async function getMermaidScriptUri(context: vscode.ExtensionContext, webview: vs
     if (!bundledMermaidUri) {
         const filePath = path.join(context.extensionPath, 'cached', 'mermaid.min.js');
         bundledMermaidUri = vscode.Uri.file(filePath);
+        try {
+            const fileUrl = bundledMermaidUri.with({ scheme: 'file' }).toString();
+            await import(fileUrl);
+        } catch {
+            // Ignore import errors as the file may not be a valid module
+        }
     }
     return webview.asWebviewUri(bundledMermaidUri).toString();
 }

--- a/src/visualization/visualizationTemplate.ts
+++ b/src/visualization/visualizationTemplate.ts
@@ -204,10 +204,28 @@ export const VISUALIZATION_TEMPLATE = `<!DOCTYPE html>
                 width: 100%;
                 height: 100%;
             }
+            .loading-overlay {
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                background: rgba(255, 255, 255, 0.8);
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 16px;
+                color: #333;
+                z-index: 2;
+            }
+            .loading-overlay.hidden {
+                display: none;
+            }
         </style>
     </head>
     <body>
         <div class="container">
+            <div id="loadingOverlay" class="loading-overlay">Loading...</div>
             <div class="controls-top">
                 <div class="filter-section">
                     <div id="typeFilters" class="filter-options"></div>

--- a/src/visualization/visualizer.ts
+++ b/src/visualization/visualizer.ts
@@ -110,6 +110,12 @@ async function getMermaidScriptUri(context: vscode.ExtensionContext, webview: vs
     if (!bundledMermaidUri) {
         const filePath = path.join(context.extensionPath, 'cached', 'mermaid.min.js');
         bundledMermaidUri = vscode.Uri.file(filePath);
+        try {
+            const fileUrl = bundledMermaidUri.with({ scheme: 'file' }).toString();
+            await import(fileUrl);
+        } catch {
+            // Ignore import errors as the file may not be a valid module
+        }
     }
     return webview.asWebviewUri(bundledMermaidUri).toString();
 }

--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -62,10 +62,12 @@ document.getElementById('mermaid-diagram').setAttribute('data-original-code', or
 document.getElementById('mermaid-diagram').innerHTML = result.svg;
 setupPanZoom();
 logMessage('Diagram rendered successfully', 'success');
+document.getElementById('loadingOverlay').classList.add('hidden');
 }).catch(function(error) {
 document.getElementById('errorContainer').textContent = 'Error rendering diagram: ' + error;
 document.getElementById('errorContainer').style.display = 'block';
 logMessage('Error rendering diagram: ' + error, 'error');
+document.getElementById('loadingOverlay').classList.add('hidden');
 });
 var vscode = acquireVsCodeApi();
 window.addEventListener('message', function(event) {


### PR DESCRIPTION
## Summary
- import cached mermaid on demand to ensure script is cached
- show a loading overlay until mermaid finishes rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841e37da8808328a69a6d0b9a7df494