### PR TITLE
Update devcontainer caching

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/node:18-bullseye

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,9 @@
 {
     "name": "TON Graph Dev Container",
-    "image": "mcr.microsoft.com/devcontainers/node:18-bullseye",
-    "postCreateCommand": "npm ci && npx playwright install --with-deps chromium"
+    "build": {
+        "dockerfile": "Dockerfile",
+        "cacheFrom": "mcr.microsoft.com/devcontainers/node:18-bullseye"
+    },
+    "postCreateCommand": "npm ci && npx playwright install --with-deps chromium",
+    "mounts": ["source=ton-graph-npm-cache,target=/home/node/.npm,type=volume"]
 }

--- a/README.md
+++ b/README.md
@@ -147,7 +147,9 @@ To work with it:
 1. Install the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension for VS Code.
 2. Run **Remote-Containers: Open Folder in Container...** from the command palette and select this repository.
 3. Wait for the container to build and dependencies to install.
-4. You can now run `npm test` or other tasks inside the container.
+4. Node dependencies are cached across rebuilds using a Docker volume mounted at `~/.npm`.
+5. Docker build caching is enabled via the `cacheFrom` property to speed up subsequent builds.
+6. You can now run `npm test` or other tasks inside the container.
 
 ### Logs
 


### PR DESCRIPTION
## Summary
- cache node dependencies with Docker volume
- speed up devcontainer build using `cacheFrom`
- document caching usage in README

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e6640d348328ba291e3613b5f3bc