### PR TITLE
Refactor filter logic into command utility

### DIFF
--- a/src/commands/filterUtils.ts
+++ b/src/commands/filterUtils.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode';
+import { ContractGraph } from '../types/graph';
+import { generateMermaidDiagram } from '../visualization/visualizer';
+import { logError } from '../logger';
+
+export function applyFilters(
+    panel: vscode.WebviewPanel,
+    originalGraph: ContractGraph,
+    selectedTypes: string[],
+    nameFilter: string
+) {
+    try {
+        const normalizedNameFilter = nameFilter ? nameFilter.trim().toLowerCase() : '';
+
+        const remainingNodeIds = new Set<string>();
+        const nodesPassingTypeFilter = originalGraph.nodes.filter(node => {
+            const nodeType = node.functionType || 'regular';
+            const shouldKeep = selectedTypes.includes(nodeType);
+            if (shouldKeep) {
+                remainingNodeIds.add(node.id);
+            }
+            return shouldKeep;
+        });
+
+        let filteredNodes = nodesPassingTypeFilter;
+
+        if (normalizedNameFilter) {
+            const matchingNodeIds = new Set<string>();
+            const nameMatchedNodes = nodesPassingTypeFilter.filter(node => {
+                const label = node.label.toLowerCase();
+                const id = node.id.toLowerCase();
+                if (label.includes(normalizedNameFilter) || id.includes(normalizedNameFilter)) {
+                    matchingNodeIds.add(node.id);
+                    return true;
+                }
+                return false;
+            });
+
+            const connectedNodeIds = new Set<string>();
+            originalGraph.edges.forEach(edge => {
+                if (matchingNodeIds.has(edge.from) && remainingNodeIds.has(edge.to)) {
+                    connectedNodeIds.add(edge.to);
+                }
+                if (matchingNodeIds.has(edge.to) && remainingNodeIds.has(edge.from)) {
+                    connectedNodeIds.add(edge.from);
+                }
+            });
+
+            const visibleNodeIds = new Set([...matchingNodeIds, ...connectedNodeIds]);
+            filteredNodes = nodesPassingTypeFilter.filter(node =>
+                visibleNodeIds.has(node.id)
+            );
+        }
+
+        const finalNodeIds = new Set(filteredNodes.map(node => node.id));
+        const filteredEdges = originalGraph.edges.filter(edge =>
+            finalNodeIds.has(edge.from) && finalNodeIds.has(edge.to)
+        );
+
+        const filteredGraph: ContractGraph = {
+            nodes: filteredNodes,
+            edges: filteredEdges,
+        };
+
+        const newMermaidDiagram = generateMermaidDiagram(filteredGraph);
+
+        panel.webview.postMessage({
+            command: 'updateDiagram',
+            diagram: newMermaidDiagram,
+        });
+    } catch (filterError: any) {
+        logError('Error applying filters', filterError);
+        vscode.window.showErrorMessage(`Error applying filters: ${filterError.message || String(filterError)}`);
+        panel.webview.postMessage({
+            command: 'filterError',
+            error: filterError.message || String(filterError),
+        });
+    }
+}

--- a/src/commands/visualize.ts
+++ b/src/commands/visualize.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
-import { createVisualizationPanel, generateMermaidDiagram } from '../visualization/visualizer';
+import { createVisualizationPanel } from '../visualization/visualizer';
 import { handleExport } from '../export/exportHandler';
 import { ContractGraph } from '../types/graph';
 import { detectLanguage, parseContractByLanguage, getFunctionTypeFilters } from '../parser/parserUtils';
 import { logError } from '../logger';
+import { applyFilters } from './filterUtils';
 
 let panel: vscode.WebviewPanel | undefined;
 
@@ -54,76 +55,9 @@ export async function visualize(context: vscode.ExtensionContext, fileUri?: vsco
                         vscode.window.showErrorMessage('Cannot apply filters: original graph data is missing.');
                         return;
                     }
-                    try {
-                        const selectedTypes = message.selectedTypes as string[];
-                        const nameFilter = message.nameFilter ? message.nameFilter.trim().toLowerCase() : '';
-
-                        const remainingNodeIds = new Set<string>();
-                        const nodesPassingTypeFilter = originalGraph.nodes.filter(node => {
-                            const nodeType = node.functionType || 'regular';
-                            const shouldKeep = selectedTypes.includes(nodeType);
-                            if (shouldKeep) {
-                                remainingNodeIds.add(node.id);
-                            }
-                            return shouldKeep;
-                        });
-
-                        let filteredNodes = nodesPassingTypeFilter;
-                        if (nameFilter) {
-                            const matchingNodeIds = new Set<string>();
-                            const nameMatchedNodes = nodesPassingTypeFilter.filter(node => {
-                                const label = node.label.toLowerCase();
-                                const id = node.id.toLowerCase();
-
-                                if (label.includes(nameFilter) || id.includes(nameFilter)) {
-                                    matchingNodeIds.add(node.id);
-                                    return true;
-                                }
-                                return false;
-                            });
-
-                            const connectedNodeIds = new Set<string>();
-                            originalGraph.edges.forEach(edge => {
-                                if (matchingNodeIds.has(edge.from) && remainingNodeIds.has(edge.to)) {
-                                    connectedNodeIds.add(edge.to);
-                                }
-                                if (matchingNodeIds.has(edge.to) && remainingNodeIds.has(edge.from)) {
-                                    connectedNodeIds.add(edge.from);
-                                }
-                            });
-
-                            const visibleNodeIds = new Set([...matchingNodeIds, ...connectedNodeIds]);
-
-                            filteredNodes = nodesPassingTypeFilter.filter(node =>
-                                visibleNodeIds.has(node.id)
-                            );
-                        }
-
-                        const finalNodeIds = new Set(filteredNodes.map(node => node.id));
-                        const filteredEdges = originalGraph.edges.filter(edge =>
-                            finalNodeIds.has(edge.from) && finalNodeIds.has(edge.to)
-                        );
-
-                        const filteredGraph: ContractGraph = {
-                            nodes: filteredNodes,
-                            edges: filteredEdges,
-                        };
-
-                        const newMermaidDiagram = generateMermaidDiagram(filteredGraph);
-
-                        panel!.webview.postMessage({
-                            command: 'updateDiagram',
-                            diagram: newMermaidDiagram
-                        });
-
-                    } catch (filterError: any) {
-                        logError('Error applying filters', filterError);
-                        vscode.window.showErrorMessage(`Error applying filters: ${filterError.message || String(filterError)}`);
-                        panel!.webview.postMessage({
-                            command: 'filterError',
-                            error: filterError.message || String(filterError)
-                        });
-                    }
+                    const selectedTypes = message.selectedTypes as string[];
+                    const nameFilter = message.nameFilter ? message.nameFilter.trim().toLowerCase() : '';
+                    applyFilters(panel!, originalGraph, selectedTypes, nameFilter);
 
                 } else {
                     await handleExport(panel!, message, context);

--- a/src/commands/visualizeProject.ts
+++ b/src/commands/visualizeProject.ts
@@ -1,9 +1,10 @@
 import * as vscode from 'vscode';
-import { createVisualizationPanel, generateMermaidDiagram } from '../visualization/visualizer';
+import { createVisualizationPanel } from '../visualization/visualizer';
 import { handleExport } from '../export/exportHandler';
 import { ContractGraph } from '../types/graph';
 import { detectLanguage, parseContractWithImports, getFunctionTypeFilters } from '../parser/parserUtils';
 import { logError } from '../logger';
+import { applyFilters } from './filterUtils';
 
 let panel: vscode.WebviewPanel | undefined;
 
@@ -59,75 +60,9 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
             panel!.webview.onDidReceiveMessage(
                 async (message) => {
                     if (message.command === 'applyFilters') {
-                        try {
-                            const selectedTypes = message.selectedTypes as string[];
-                            const nameFilter = message.nameFilter ? message.nameFilter.trim().toLowerCase() : '';
-
-                            const remainingNodeIds = new Set<string>();
-                            const nodesPassingTypeFilter = originalGraph.nodes.filter(node => {
-                                const nodeType = node.functionType || 'regular';
-                                const shouldKeep = selectedTypes.includes(nodeType);
-                                if (shouldKeep) {
-                                    remainingNodeIds.add(node.id);
-                                }
-                                return shouldKeep;
-                            });
-
-                            let filteredNodes = nodesPassingTypeFilter;
-                            if (nameFilter) {
-                                const matchingNodeIds = new Set<string>();
-                                const nameMatchedNodes = nodesPassingTypeFilter.filter(node => {
-                                    const label = node.label.toLowerCase();
-                                    const id = node.id.toLowerCase();
-
-                                    if (label.includes(nameFilter) || id.includes(nameFilter)) {
-                                        matchingNodeIds.add(node.id);
-                                        return true;
-                                    }
-                                    return false;
-                                });
-
-                                const connectedNodeIds = new Set<string>();
-                                originalGraph.edges.forEach(edge => {
-                                    if (matchingNodeIds.has(edge.from) && remainingNodeIds.has(edge.to)) {
-                                        connectedNodeIds.add(edge.to);
-                                    }
-                                    if (matchingNodeIds.has(edge.to) && remainingNodeIds.has(edge.from)) {
-                                        connectedNodeIds.add(edge.from);
-                                    }
-                                });
-
-                                const visibleNodeIds = new Set([...matchingNodeIds, ...connectedNodeIds]);
-                                filteredNodes = nodesPassingTypeFilter.filter(node =>
-                                    visibleNodeIds.has(node.id)
-                                );
-                            }
-
-                            const finalNodeIds = new Set(filteredNodes.map(node => node.id));
-                            const filteredEdges = originalGraph.edges.filter(edge =>
-                                finalNodeIds.has(edge.from) && finalNodeIds.has(edge.to)
-                            );
-
-                            const filteredGraph: ContractGraph = {
-                                nodes: filteredNodes,
-                                edges: filteredEdges,
-                            };
-
-                            const newMermaidDiagram = generateMermaidDiagram(filteredGraph);
-
-                            panel!.webview.postMessage({
-                                command: 'updateDiagram',
-                                diagram: newMermaidDiagram
-                            });
-
-                        } catch (filterError: any) {
-                            logError('Error applying filters', filterError);
-                            vscode.window.showErrorMessage(`Error applying filters: ${filterError.message || String(filterError)}`);
-                            panel!.webview.postMessage({
-                                command: 'filterError',
-                                error: filterError.message || String(filterError)
-                            });
-                        }
+                        const selectedTypes = message.selectedTypes as string[];
+                        const nameFilter = message.nameFilter ? message.nameFilter.trim().toLowerCase() : '';
+                        applyFilters(panel!, originalGraph, selectedTypes, nameFilter);
                     } else {
                         await handleExport(panel!, message, context);
                     }


### PR DESCRIPTION
## Summary
- extract common filtering to `applyFilters` utility
- call `applyFilters` from visualization commands

## Testing
- `npm install`
- `npm test`
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_6841ef7c79288328a7314957543ad412