### PR TITLE
Integrate Winston logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ To work with it:
 
 ### Logs
 
-Runtime logs are written to `logs/extension.log` in the project root. The file
-rotates when it reaches 1 MB and up to five log files are kept.
+All runtime messages are written to `logs/extension.log` in the repository root.
+The log file rotates when it reaches 1&nbsp;MB and up to five files are kept.
+You can also view logs directly in VS Code under **Output** → **TON Graph**.
 
 ## Requirements
 

--- a/src/commands/filterUtils.ts
+++ b/src/commands/filterUtils.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { ContractGraph } from '../types/graph';
 import { generateMermaidDiagram } from '../visualization/visualizer';
-import { logError } from '../logger';
+import logger from '../logging/logger';
 
 export function applyFilters(
     panel: vscode.WebviewPanel,
@@ -69,7 +69,7 @@ export function applyFilters(
             diagram: newMermaidDiagram,
         });
     } catch (filterError: any) {
-        logError('Error applying filters', filterError);
+        logger.error('Error applying filters', filterError);
         vscode.window.showErrorMessage(`Error applying filters: ${filterError.message || String(filterError)}`);
         panel.webview.postMessage({
             command: 'filterError',

--- a/src/commands/visualize.ts
+++ b/src/commands/visualize.ts
@@ -3,7 +3,7 @@ import { createVisualizationPanel } from '../visualization/visualizer';
 import { handleExport } from '../export/exportHandler';
 import { ContractGraph } from '../types/graph';
 import { detectLanguage, parseContractByLanguage, getFunctionTypeFilters } from '../parser/parserUtils';
-import { logError } from '../logger';
+import logger from '../logging/logger';
 import { applyFilters } from './filterUtils';
 
 let panel: vscode.WebviewPanel | undefined;
@@ -51,7 +51,7 @@ export async function visualize(context: vscode.ExtensionContext, fileUri?: vsco
             async (message) => {
                 if (message.command === 'applyFilters') {
                     if (!originalGraph) {
-                        logError('Original graph data not available for filtering');
+                        logger.error('Original graph data not available for filtering');
                         vscode.window.showErrorMessage('Cannot apply filters: original graph data is missing.');
                         return;
                     }
@@ -69,7 +69,7 @@ export async function visualize(context: vscode.ExtensionContext, fileUri?: vsco
 
         panel!.reveal(vscode.ViewColumn.Beside);
     } catch (error: any) {
-        logError('Error visualizing contract', error);
+        logger.error('Error visualizing contract', error);
         vscode.window.showErrorMessage(`Error visualizing contract: ${error.message || String(error)}`);
         originalGraph = null;
     }

--- a/src/commands/visualizeProject.ts
+++ b/src/commands/visualizeProject.ts
@@ -3,7 +3,7 @@ import { createVisualizationPanel } from '../visualization/visualizer';
 import { handleExport } from '../export/exportHandler';
 import { ContractGraph } from '../types/graph';
 import { detectLanguage, parseContractWithImports, getFunctionTypeFilters } from '../parser/parserUtils';
-import { logError } from '../logger';
+import logger from '../logging/logger';
 import { applyFilters } from './filterUtils';
 
 let panel: vscode.WebviewPanel | undefined;
@@ -75,7 +75,7 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
             panel!.reveal(vscode.ViewColumn.Beside);
         });
     } catch (error: any) {
-        logError('Error visualizing contract project', error);
+        logger.error('Error visualizing contract project', error);
         vscode.window.showErrorMessage(`Error visualizing contract project: ${error.message || String(error)}`);
     }
 }

--- a/src/export/exportHandler.ts
+++ b/src/export/exportHandler.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { filterMermaidDiagram, generateVisualizationHtml } from '../visualization/templates';
-import { logError } from '../logger';
+import logger from '../logging/logger';
 
 // URI to the bundled Mermaid script
 let bundledMermaidUri: vscode.Uri | undefined;
@@ -49,7 +49,7 @@ export async function handleExport(
                 break;
         }
     } catch (error: any) {
-        logError('Error handling export', error);
+        logger.error('Error handling export', error);
         vscode.window.showErrorMessage(`Error handling export: ${error.message || String(error)}`);
         panel.webview.postMessage({
             command: 'saveResult',
@@ -83,7 +83,7 @@ async function handleApplyFilters(
         const originalGraph = response.content;
 
         if (!originalGraph) {
-            logError('No original graph data received');
+            logger.error('No original graph data received');
             throw new Error('No original graph data received');
         }
 
@@ -115,11 +115,11 @@ async function handleApplyFilters(
                 nameFilter
             });
         } catch (updateError) {
-            logError('Error updating webview content', updateError);
+            logger.error('Error updating webview content', updateError);
             throw updateError;
         }
     } catch (error: any) {
-        logError('Error applying filters', error);
+        logger.error('Error applying filters', error);
         panel.webview.postMessage({
             command: 'filtersApplied',
             success: false,
@@ -285,7 +285,7 @@ async function handlePngExport(
 
             // Validate the data URL format
             if (!pngDataUrl.startsWith('data:image/png;base64,')) {
-                logError('Invalid PNG data URL format', pngDataUrl.substring(0, 50) + '...');
+                logger.error('Invalid PNG data URL format', pngDataUrl.substring(0, 50) + '...');
                 throw new Error('Invalid PNG data URL format');
             }
 
@@ -301,7 +301,7 @@ async function handlePngExport(
                 path: pngUri.fsPath
             });
         } catch (error: any) {
-            logError('Error in PNG export', error);
+            logger.error('Error in PNG export', error);
             vscode.window.showErrorMessage(`Failed to export PNG: ${error.message}`);
             throw error;
         }
@@ -357,7 +357,7 @@ async function handleJpgExport(
 
             // Validate the data URL format
             if (!jpgDataUrl.startsWith('data:image/jpeg;base64,')) {
-                logError('Invalid JPG data URL format', jpgDataUrl.substring(0, 50) + '...');
+                logger.error('Invalid JPG data URL format', jpgDataUrl.substring(0, 50) + '...');
                 throw new Error('Invalid JPG data URL format');
             }
 
@@ -373,7 +373,7 @@ async function handleJpgExport(
                 path: jpgUri.fsPath
             });
         } catch (error: any) {
-            logError('Error in JPG export', error);
+            logger.error('Error in JPG export', error);
             vscode.window.showErrorMessage(`Failed to export JPG: ${error.message}`);
             throw error;
         }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,9 +1,0 @@
-import * as vscode from 'vscode';
-
-export const outputChannel = vscode.window.createOutputChannel('TON Graph');
-
-export function logError(message: string, err?: unknown): void {
-    const details = err ? (err instanceof Error ? err.message : String(err)) : '';
-    const formatted = details ? `${message}: ${details}` : message;
-    outputChannel.appendLine(formatted);
-}

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,23 +1,44 @@
 import { createLogger, format, transports } from 'winston';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as vscode from 'vscode';
+import { Writable } from 'stream';
+
+export const outputChannel = vscode.window.createOutputChannel('TON Graph');
 
 const logsDir = path.resolve(__dirname, '../../logs');
 if (!fs.existsSync(logsDir)) {
   fs.mkdirSync(logsDir, { recursive: true });
 }
 
+const logFormat = format.combine(
+  format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
+  format.printf(({ timestamp, level, message, ...meta }) => {
+    const rest = Object.keys(meta).length ? ` ${JSON.stringify(meta)}` : '';
+    return `${timestamp} [${level}] ${message}${rest}`;
+  })
+);
+
+const outputStream = new Writable({
+  write(chunk, _enc, callback) {
+    outputChannel.appendLine(chunk.toString().trim());
+    callback();
+  },
+});
+
 const logger = createLogger({
   level: 'info',
-  format: format.json(),
+  format: logFormat,
   transports: [
-    new transports.Console({ format: format.json() }),
     new transports.File({
       filename: path.join(logsDir, 'extension.log'),
       maxsize: 1024 * 1024,
-      maxFiles: 5
-    })
-  ]
+      maxFiles: 5,
+    }),
+    new transports.Stream({
+      stream: outputStream,
+    }),
+  ],
 });
 
 export default logger;

--- a/src/parser/importHandler.ts
+++ b/src/parser/importHandler.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { logError } from '../logger';
+import logger from '../logging/logger';
 
 function isPathInsideWorkspace(filePath: string): boolean {
     const folders = vscode.workspace.workspaceFolders;
@@ -53,7 +53,7 @@ export async function processFuncImports(
         const includePath = match[1];
         const fullPath = path.resolve(baseDir, includePath);
         if (!isPathInsideWorkspace(fullPath)) {
-            logError(`Import outside workspace: ${includePath}`);
+            logger.error(`Import outside workspace: ${includePath}`);
             continue;
         }
 
@@ -66,7 +66,7 @@ export async function processFuncImports(
         try {
             await fs.promises.access(fullPath);
         } catch {
-            logError(`Included file not found: ${fullPath}`);
+            logger.error(`Included file not found: ${fullPath}`);
             continue;
         }
 
@@ -82,7 +82,7 @@ export async function processFuncImports(
             importedCode.push(nestedImports.importedCode);
             importedFilePaths.push(...nestedImports.importedFilePaths);
         } catch (error) {
-            logError(`Error processing import ${fullPath}`, error);
+            logger.error(`Error processing import ${fullPath}`, error);
         }
     }
 
@@ -126,7 +126,7 @@ export async function processTactImports(
                 fullPath = packagePath;
                 // Could further resolve subpaths here
             } else {
-                logError(`Package not found: ${packageName}`);
+                logger.error(`Package not found: ${packageName}`);
                 continue;
             }
         } else {
@@ -140,7 +140,7 @@ export async function processTactImports(
         }
 
         if (!isPathInsideWorkspace(fullPath)) {
-            logError(`Import outside workspace: ${importPath}`);
+            logger.error(`Import outside workspace: ${importPath}`);
             continue;
         }
 
@@ -153,7 +153,7 @@ export async function processTactImports(
         try {
             await fs.promises.access(fullPath);
         } catch {
-            logError(`Imported file not found: ${fullPath}`);
+            logger.error(`Imported file not found: ${fullPath}`);
             continue;
         }
 
@@ -169,7 +169,7 @@ export async function processTactImports(
             importedCode.push(nestedImports.importedCode);
             importedFilePaths.push(...nestedImports.importedFilePaths);
         } catch (error) {
-            logError(`Error processing import ${fullPath}`, error);
+            logger.error(`Error processing import ${fullPath}`, error);
         }
     }
 
@@ -213,7 +213,7 @@ export async function processTolkImports(
                 fullPath = packagePath;
                 // Could further resolve subpaths here
             } else {
-                logError(`Package not found: ${packageName}`);
+                logger.error(`Package not found: ${packageName}`);
                 continue;
             }
         } else {
@@ -227,7 +227,7 @@ export async function processTolkImports(
         }
 
         if (!isPathInsideWorkspace(fullPath)) {
-            logError(`Import outside workspace: ${importPath}`);
+            logger.error(`Import outside workspace: ${importPath}`);
             continue;
         }
 
@@ -240,7 +240,7 @@ export async function processTolkImports(
         try {
             await fs.promises.access(fullPath);
         } catch {
-            logError(`Imported file not found: ${fullPath}`);
+            logger.error(`Imported file not found: ${fullPath}`);
             continue;
         }
 
@@ -256,7 +256,7 @@ export async function processTolkImports(
             importedCode.push(nestedImports.importedCode);
             importedFilePaths.push(...nestedImports.importedFilePaths);
         } catch (error) {
-            logError(`Error processing import ${fullPath}`, error);
+            logger.error(`Error processing import ${fullPath}`, error);
         }
     }
 

--- a/src/visualization/templates.ts
+++ b/src/visualization/templates.ts
@@ -1,5 +1,5 @@
 export { generateVisualizationHtml } from "./htmlTemplate";
-import { logError } from '../logger';
+import logger from '../logging/logger';
 // generateErrorHtml remains useful for displaying initialization errors
 export function generateErrorHtml(message: string, mermaidScriptUri?: string): string {
     // Use error styles from "Copy"
@@ -407,7 +407,7 @@ export function filterMermaidDiagram(diagram: string, selectedTypes: string[], n
         const result = lines.join("\n");
         return validateAndFixDiagram(result);
     } catch (error) {
-        logError('Error in filterMermaidDiagram', error);
+        logger.error('Error in filterMermaidDiagram', error);
         return diagram;
     }
 }
@@ -458,7 +458,7 @@ function validateAndFixDiagram(diagramCode: string): string {
 
         return cleanedLines.join('\\n');
     } catch (error) {
-        logError('Error in validateAndFixDiagram', error);
+        logger.error('Error in validateAndFixDiagram', error);
         return diagramCode; // Return original on validation error
     }
 }

--- a/src/visualization/visualizer.ts
+++ b/src/visualization/visualizer.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { ContractGraph } from '../types/graph';
 import { GraphNodeKind } from '../types/graphNodeKind';
 import { generateVisualizationHtml, filterMermaidDiagram } from './templates';
-import { logError } from '../logger';
+import logger from '../logging/logger';
 
 // Map panels to their original graphs
 const panelGraphs = new WeakMap<vscode.WebviewPanel, ContractGraph>();
@@ -63,7 +63,7 @@ export function createVisualizationPanel(
         // Set the HTML content for the panel
         panel.webview.html = html;
     }).catch(error => {
-        logError('Error loading Mermaid library', error);
+        logger.error('Error loading Mermaid library', error);
         vscode.window.showErrorMessage(`Error loading Mermaid library: ${error.message}`);
     });
 
@@ -79,7 +79,7 @@ export function createVisualizationPanel(
                     // Handle other messages (export commands, etc.)
                 }
             } catch (error) {
-                logError('Error handling message from webview', error);
+                logger.error('Error handling message from webview', error);
                 panel.webview.postMessage({
                     command: 'filterError',
                     error: error instanceof Error ? error.message : String(error)
@@ -160,7 +160,7 @@ function handleFilterRequest(panel: vscode.WebviewPanel, selectedTypes: string[]
         });
 
     } catch (error) {
-        logError('Error handling filter request', error);
+        logger.error('Error handling filter request', error);
         panel.webview.postMessage({
             command: 'filterError',
             error: error instanceof Error ? error.message : String(error)

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import logger from '../src/logging/logger';
+import logger, { outputChannel } from '../src/logging/logger';
 import { transports as winstonTransports } from 'winston';
 
 describe('Logger', () => {
@@ -8,5 +8,11 @@ describe('Logger', () => {
     expect(fileTransport).to.exist;
     expect((fileTransport as any).maxsize).to.equal(1024 * 1024);
     expect((fileTransport as any).maxFiles).to.equal(5);
+  });
+
+  it('includes output channel transport', () => {
+    const streamTransport = logger.transports.find(t => t instanceof winstonTransports.Stream);
+    expect(streamTransport).to.exist;
+    expect(outputChannel).to.exist;
   });
 });


### PR DESCRIPTION
## Summary
- use Winston to log to file and VS Code Output Channel
- refactor all code to use the new logger
- document how to view logs
- adjust logger tests for new transport

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f1a4fcd4832892d0f2b03fa72b3b