### PR TITLE
Refactor Tolk parser

### DIFF
--- a/src/parser/tolkParser.ts
+++ b/src/parser/tolkParser.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ContractGraph, ContractNode } from '../types/graph';
+import { ContractGraph, ContractNode, GraphEdge } from '../types/graph';
 import { GraphNodeKind } from '../types/graphNodeKind';
 
 // List of built-in functions to exclude
@@ -39,159 +39,146 @@ function identifyGlobalVariables(code: string): Set<string> {
     return globalVars;
 }
 
-export async function parseTolkContract(code: string): Promise<ContractGraph> {
-    const graph: ContractGraph = {
-        nodes: [],
-        edges: []
-    };
+export interface FunctionDeclaration {
+    name: string;
+    isGet: boolean;
+    decorators: Set<string>;
+    lineIndex: number;
+}
 
-    // Extract contract name from filename or use default
-    let contractName = "Contract";
-    const editor = vscode.window.activeTextEditor;
-    if (editor) {
-        const fileName = path.basename(editor.document.fileName);
-        contractName = fileName.split('.')[0];
-    }
+export interface TolkFunctionInfo {
+    id: string;
+    params: string;
+    body: string;
+    decorators: Set<string>;
+    isGet: boolean;
+    type: string;
+}
 
-    // Process code by normalizing line breaks and removing comments
-    const normalizedCode = code.replace(/\r\n/g, '\n');
-    const cleanedCode = removeCommentsFromCode(normalizedCode);
-
-    // Identify global variables
-    const globalVariables = identifyGlobalVariables(cleanedCode);
-
-    // Find all function declarations
-    const functions = new Map<string, { id: string, params: string, body: string, type: string }>();
-
-    // Process the code line by line to better handle functions with complex param types
-    const lines = cleanedCode.split('\n');
-
+/**
+ * Finds function declarations within the given lines of code.
+ * @param lines Array of source code lines.
+ * @param globalVariables Set of global variable names to exclude.
+ * @returns Discovered function declarations with metadata.
+ */
+export function findFunctionDeclarations(lines: string[], globalVariables: Set<string>): FunctionDeclaration[] {
+    const declarations: FunctionDeclaration[] = [];
     for (let i = 0; i < lines.length; i++) {
-        // First look for function declarations
         const funcDeclMatch = /(?:@([a-zA-Z_]+)\s+)*\b(?:(get)\s+(?:fun\s+)?|fun\s+)([a-zA-Z_][a-zA-Z0-9_]*)/.exec(lines[i]);
-
         if (funcDeclMatch) {
-            const decorator = funcDeclMatch[1] || '';
             const isGet = !!funcDeclMatch[2];
             const funcName = funcDeclMatch[3];
 
-            // Find all decorators that appear before the function declaration (like @pure, @inline)
-            // Look at the current line and possibly previous line for decorators
-            let decorators = new Set<string>();
+            const decorators = new Set<string>();
             const currentLine = lines[i];
             const prevLine = i > 0 ? lines[i - 1] : '';
 
-            // Check current line for decorators
-            let decoratorMatch;
+            let decoratorMatch: RegExpExecArray | null;
             const decoratorRegex = /@([a-zA-Z_]+)/g;
             while ((decoratorMatch = decoratorRegex.exec(currentLine)) !== null) {
                 decorators.add(decoratorMatch[1]);
             }
 
-            // Check previous line if it contains only a decorator
             if (prevLine.trim().startsWith('@') && !prevLine.includes('fun')) {
                 const prevDecorators = prevLine.match(/@([a-zA-Z_]+)/g) || [];
                 for (const dec of prevDecorators) {
-                    decorators.add(dec.substring(1)); // Remove the @ symbol
+                    decorators.add(dec.substring(1));
                 }
             }
 
-            // Skip built-in functions and identified global variables
             if (BUILT_IN_FUNCTIONS.has(funcName) || globalVariables.has(funcName)) {
                 continue;
             }
 
-            // Check if this function declaration spans multiple lines
-            let fullDeclaration = lines[i];
-            let lineIndex = i;
-            let openParens = (fullDeclaration.match(/\(/g) || []).length;
-            let closeParens = (fullDeclaration.match(/\)/g) || []).length;
-
-            // If parentheses aren't balanced, look ahead to find the complete declaration
-            while (openParens > closeParens && lineIndex + 1 < lines.length) {
-                lineIndex++;
-                fullDeclaration += '\n' + lines[lineIndex];
-                openParens += (lines[lineIndex].match(/\(/g) || []).length;
-                closeParens += (lines[lineIndex].match(/\)/g) || []).length;
-            }
-
-            // Extract parameters
-            const paramMatch = /\((.*?)\)(?:\s*:\s*[^{;]+)?/.exec(fullDeclaration);
-            const params = paramMatch ? paramMatch[1] : '';
-
-            // Look ahead for function body or asm
-            let bodyText = '';
-            let isAsm = false;
-
-            // Look for opening brace or asm keyword
-            for (let j = lineIndex; j < lines.length; j++) {
-                if (lines[j].includes('{')) {
-                    // Regular function with braces
-                    let braceCount = 1;
-                    let bodyLines = [];
-
-                    // Start from the line after the opening brace
-                    for (let k = j + 1; k < lines.length && braceCount > 0; k++) {
-                        braceCount += (lines[k].match(/{/g) || []).length;
-                        braceCount -= (lines[k].match(/}/g) || []).length;
-
-                        if (braceCount > 0) {
-                            bodyLines.push(lines[k]);
-                        }
-                    }
-
-                    bodyText = bodyLines.join('\n');
-                    break;
-                } else if (lines[j].includes('asm')) {
-                    // Asm function
-                    isAsm = true;
-                    const asmLine = lines[j];
-                    const stringMatches = asmLine.match(/("[^"]*"|'[^']*')/g) || [];
-                    bodyText = stringMatches.join(' ');
-                    break;
-                }
-            }
-
-            // Skip functions without implementation
-            if (!bodyText.trim()) {
-                continue;
-            }
-
-            // Determine function type
-            let funcType;
-            if (isGet) {
-                funcType = 'get';
-            } else if (decorators.has('pure')) {
-                funcType = 'pure_fun';
-            } else if (decorators.has('inline')) {
-                funcType = 'inline_fun';
-            } else {
-                funcType = 'fun';
-            }
-
-            functions.set(funcName, {
-                id: funcName,
-                params,
-                body: bodyText,
-                type: funcType
-            });
+            declarations.push({ name: funcName, isGet, decorators, lineIndex: i });
         }
     }
+    return declarations;
+}
 
-    // Create nodes for each function
-    functions.forEach((func, name) => {
-        const node: ContractNode = {
-            id: name,
-            label: `${name}(${func.params})`,
-            type: GraphNodeKind.Function,
-            contractName,
-            parameters: func.params.split(',').map(p => p.trim()).filter(p => p),
-            functionType: func.type as any
-        };
-        graph.nodes.push(node);
-    });
+/**
+ * Parses the parameter list of a function declaration.
+ * @param lines Array of source code lines.
+ * @param startLine Line index where the declaration begins.
+ * @returns Parameter string and the line index where the declaration ends.
+ */
+export function parseParameters(lines: string[], startLine: number): { params: string; endLine: number } {
+    let fullDeclaration = lines[startLine];
+    let lineIndex = startLine;
+    let openParens = (fullDeclaration.match(/\(/g) || []).length;
+    let closeParens = (fullDeclaration.match(/\)/g) || []).length;
 
-    // Second pass: analyze function calls without nested iterations
+    while (openParens > closeParens && lineIndex + 1 < lines.length) {
+        lineIndex++;
+        fullDeclaration += '\n' + lines[lineIndex];
+        openParens += (lines[lineIndex].match(/\(/g) || []).length;
+        closeParens += (lines[lineIndex].match(/\)/g) || []).length;
+    }
+
+    const paramMatch = /\((.*?)\)(?:\s*:\s*[^{;]+)?/.exec(fullDeclaration);
+    const params = paramMatch ? paramMatch[1] : '';
+    return { params, endLine: lineIndex };
+}
+
+/**
+ * Extracts the body of a function starting from a given line.
+ * @param lines Array of source code lines.
+ * @param fromLine Line index where the search for the body should start.
+ * @returns Function body text and whether it is an asm function.
+ */
+export function extractBody(lines: string[], fromLine: number): { body: string; isAsm: boolean } {
+    let bodyText = '';
+    let isAsm = false;
+    for (let j = fromLine; j < lines.length; j++) {
+        if (lines[j].includes('{')) {
+            let braceCount = 1;
+            const bodyLines: string[] = [];
+            for (let k = j + 1; k < lines.length && braceCount > 0; k++) {
+                braceCount += (lines[k].match(/{/g) || []).length;
+                braceCount -= (lines[k].match(/}/g) || []).length;
+                if (braceCount > 0) {
+                    bodyLines.push(lines[k]);
+                }
+            }
+            bodyText = bodyLines.join('\n');
+            break;
+        } else if (lines[j].includes('asm')) {
+            isAsm = true;
+            const asmLine = lines[j];
+            const stringMatches = asmLine.match(/("[^"]*"|'[^']*')/g) || [];
+            bodyText = stringMatches.join(' ');
+            break;
+        }
+    }
+    return { body: bodyText, isAsm };
+}
+
+/**
+ * Determines the type of a function based on decorators and modifiers.
+ * @param isGet Indicates if the function is declared with the `get` keyword.
+ * @param decorators Set of decorators applied to the function.
+ * @returns Normalized function type string.
+ */
+export function determineFunctionType(isGet: boolean, decorators: Set<string>): string {
+    if (isGet) {
+        return 'get';
+    }
+    if (decorators.has('pure')) {
+        return 'pure_fun';
+    }
+    if (decorators.has('inline')) {
+        return 'inline_fun';
+    }
+    return 'fun';
+}
+
+/**
+ * Analyzes calls between discovered functions and returns graph edges.
+ * @param functions Map of function information keyed by function name.
+ * @returns Array of edges representing function calls.
+ */
+export function analyzeFunctionCalls(functions: Map<string, TolkFunctionInfo>): GraphEdge[] {
+    const edges: GraphEdge[] = [];
     const functionNames = Array.from(functions.keys()).sort((a, b) => b.length - a.length);
     const callRegex = new RegExp(`\\b(${functionNames.join('|')})\\s*\\(`, 'g');
 
@@ -213,11 +200,7 @@ export async function parseTolkContract(code: string): Promise<ContractGraph> {
 
                 const edgeKey = `${funcName}->${calledFuncName}`;
                 if (!addedEdges.has(edgeKey)) {
-                    graph.edges.push({
-                        from: funcName,
-                        to: calledFuncName,
-                        label: ''
-                    });
+                    edges.push({ from: funcName, to: calledFuncName, label: '' });
                     addedEdges.add(edgeKey);
                 }
             }
@@ -226,5 +209,58 @@ export async function parseTolkContract(code: string): Promise<ContractGraph> {
         callRegex.lastIndex = 0;
     });
 
+    return edges;
+}
+
+export async function parseTolkContract(code: string): Promise<ContractGraph> {
+    const graph: ContractGraph = { nodes: [], edges: [] };
+
+    let contractName = 'Contract';
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+        const fileName = path.basename(editor.document.fileName);
+        contractName = fileName.split('.')[0];
+    }
+
+    const normalizedCode = code.replace(/\r\n/g, '\n');
+    const cleanedCode = removeCommentsFromCode(normalizedCode);
+
+    const globalVariables = identifyGlobalVariables(cleanedCode);
+    const lines = cleanedCode.split('\n');
+
+    const declarations = findFunctionDeclarations(lines, globalVariables);
+    const functions = new Map<string, TolkFunctionInfo>();
+
+    for (const decl of declarations) {
+        const { params, endLine } = parseParameters(lines, decl.lineIndex);
+        const { body } = extractBody(lines, endLine);
+        if (!body.trim()) {
+            continue;
+        }
+        const type = determineFunctionType(decl.isGet, decl.decorators);
+        functions.set(decl.name, {
+            id: decl.name,
+            params,
+            body,
+            decorators: decl.decorators,
+            isGet: decl.isGet,
+            type
+        });
+    }
+
+    functions.forEach(func => {
+        const node: ContractNode = {
+            id: func.id,
+            label: `${func.id}(${func.params})`,
+            type: GraphNodeKind.Function,
+            contractName,
+            parameters: func.params.split(',').map(p => p.trim()).filter(p => p),
+            functionType: func.type as any
+        };
+        graph.nodes.push(node);
+    });
+
+    graph.edges.push(...analyzeFunctionCalls(functions));
+
     return graph;
-} 
+}

--- a/test/tolkParserFunctions.test.ts
+++ b/test/tolkParserFunctions.test.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    findFunctionDeclarations,
+    parseParameters,
+    extractBody,
+    determineFunctionType,
+    analyzeFunctionCalls,
+    TolkFunctionInfo
+} from '../src/parser/tolkParser';
+
+describe('Tolk parser helper functions', () => {
+    const code = fs.readFileSync(path.join(__dirname, 'tolk_sample.tolk'), 'utf-8');
+    const lines = code.replace(/\r\n/g, '\n').split('\n');
+
+    it('finds function declarations', () => {
+        const decls = findFunctionDeclarations(lines, new Set());
+        const names = decls.map(d => d.name);
+        expect(names).to.include('foo');
+        expect(names).to.include('bar');
+    });
+
+    it('extracts parameters and body', () => {
+        const decls = findFunctionDeclarations(lines, new Set());
+        const foo = decls.find(d => d.name === 'foo')!;
+        const { params, endLine } = parseParameters(lines, foo.lineIndex);
+        const { body } = extractBody(lines, endLine);
+        expect(params).to.equal('');
+        expect(body.trim()).to.equal('bar();');
+    });
+
+    it('determines function type', () => {
+        const type = determineFunctionType(false, new Set());
+        expect(type).to.equal('fun');
+    });
+
+    it('analyzes function calls', () => {
+        const decls = findFunctionDeclarations(lines, new Set());
+        const functions = new Map<string, TolkFunctionInfo>();
+        for (const d of decls) {
+            const { params, endLine } = parseParameters(lines, d.lineIndex);
+            const { body } = extractBody(lines, endLine);
+            functions.set(d.name, {
+                id: d.name,
+                params,
+                body,
+                decorators: d.decorators,
+                isGet: d.isGet,
+                type: determineFunctionType(d.isGet, d.decorators)
+            });
+        }
+        const edges = analyzeFunctionCalls(functions);
+        expect(edges).to.deep.include({ from: 'foo', to: 'bar', label: '' });
+    });
+});


### PR DESCRIPTION
## Summary
- split `parseTolkContract` logic into helper functions
- document each helper with JSDoc
- export helper functions for reuse
- add unit tests for new functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841f32c5c708328bb9c1e950d2ba434