### PR TITLE
Add coverage thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
           node-version: '20'
       - run: npm install
       - run: npm run test -- --coverage --reporter=json-summary
+      - name: Check coverage thresholds
+        run: npx c8 check-coverage --lines 85 --branches 80 --functions 85
       - uses: actions/upload-artifact@v3
         with:
           name: coverage-baseline

--- a/package.json
+++ b/package.json
@@ -144,5 +144,11 @@
         "pic/**/*",
         "README.md",
         "LICENSE"
-    ]
+    ],
+    "nyc": {
+        "check-coverage": true,
+        "lines": 85,
+        "branches": 80,
+        "functions": 85
+    }
 }


### PR DESCRIPTION
## Summary
- enforce coverage thresholds in package.json
- add coverage check step to CI workflow

## Testing
- `npm test`
- `npx c8 check-coverage --lines 85 --branches 80 --functions 85` *(fails: branches coverage < 80)*

------
https://chatgpt.com/codex/tasks/task_e_6841fa27310083288a6717630c1a4bc9