### PR TITLE
Add Codecov integration and coverage checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
           npm run test -- --coverage
           npx nyc report --reporter=json
           cp coverage/coverage-final.json artifacts/coverage-baseline.json
+      - name: Check coverage thresholds
+        run: npx nyc check-coverage
       - name: Package extension
         run: npx vsce package
       - name: Upload coverage baseline
@@ -32,3 +34,8 @@ jobs:
         with:
           name: coverage-baseline
           path: artifacts/coverage-baseline.json
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TON Graph
 
+[![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/main/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
+
 A Visual Studio Code extension for visualizing function call graphs in TON smart contracts written in FunC, Tact, and Tolk.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.

--- a/package.json
+++ b/package.json
@@ -188,6 +188,10 @@
     ],
     "require": [
       "ts-node/register"
-    ]
+    ],
+    "check-coverage": true,
+    "lines": 85,
+    "branches": 80,
+    "functions": 85
   }
 }


### PR DESCRIPTION
## Summary
- integrate Codecov upload in CI
- enforce NYC coverage thresholds in `package.json`
- add a coverage badge to the README
- fail the build if coverage is insufficient

## Testing
- `npm test -- --coverage` *(fails: Coverage for lines/functions/branches does not meet global threshold)*

------
https://chatgpt.com/codex/tasks/task_e_684201232c248328925204d7ddf3e253