### PR TITLE
Add deleteApiKey command and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "onCommand:ton-graph.visualize",
     "onCommand:ton-graph.visualizeProject",
     "onCommand:ton-graph.setApiKey",
+    "onCommand:ton-graph.deleteApiKey",
     "onLanguage:func",
     "onLanguage:tact",
     "onLanguage:tolk"
@@ -89,6 +90,10 @@
       {
         "command": "ton-graph.setApiKey",
         "title": "TON Graph: Set API Key"
+      },
+      {
+        "command": "ton-graph.deleteApiKey",
+        "title": "TON Graph: Delete API Key"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { visualize, visualizeProject } from './commands';
-import { setApiKey } from './secrets/tokenManager';
+import { setApiKey, deleteApiKey } from './secrets/tokenManager';
 
 export function activate(context: vscode.ExtensionContext) {
     const cachedDir = vscode.Uri.file(path.join(context.extensionPath, 'cached'));
@@ -34,7 +34,12 @@ export function activate(context: vscode.ExtensionContext) {
         }
     });
 
-    context.subscriptions.push(apiKeyDisposable);
+    const deleteApiKeyDisposable = vscode.commands.registerCommand('ton-graph.deleteApiKey', async () => {
+        await deleteApiKey(context);
+        vscode.window.showInformationMessage('TON Graph API key deleted');
+    });
+
+    context.subscriptions.push(apiKeyDisposable, deleteApiKeyDisposable);
 }
 
 export function deactivate() {}

--- a/test/tokenManager.test.ts
+++ b/test/tokenManager.test.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', {});
+import { setApiKey, deleteApiKey, getApiKey } from '../src/secrets/tokenManager';
+
+class TestSecrets {
+    private storage: Record<string, any> = {};
+    async get(key: string): Promise<any> {
+        return this.storage[key];
+    }
+    async store(key: string, value: any): Promise<void> {
+        this.storage[key] = value;
+    }
+    async delete(key: string): Promise<void> {
+        delete this.storage[key];
+    }
+}
+
+describe('tokenManager', () => {
+    it('removes the stored API key', async () => {
+        const context = { secrets: new TestSecrets() } as any;
+        await setApiKey(context, 'SECRET');
+        await deleteApiKey(context);
+        const value = await getApiKey(context);
+        expect(value).to.be.undefined;
+    });
+});


### PR DESCRIPTION
## Summary
- register `ton-graph.deleteApiKey` command
- document the new command in `package.json`
- ensure stored API keys can be removed via a unit test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68420c580b0083289b68b8337287a94b