### PR TITLE
Update NYC coverage thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage
       - name: Check coverage thresholds
-        run: npx nyc check-coverage
+        run: npx nyc check-coverage --lines=85 --branches=80 --functions=85
       - name: Package extension
         run: npx vsce package
       - name: Upload coverage baseline

--- a/package.json
+++ b/package.json
@@ -197,8 +197,8 @@
       "ts-node/register"
     ],
     "check-coverage": true,
-    "lines": 50,
-    "branches": 30,
-    "functions": 60
+    "lines": 85,
+    "branches": 80,
+    "functions": 85
   }
 }


### PR DESCRIPTION
## Summary
- bump NYC coverage thresholds in `package.json`
- enforce same thresholds in CI workflow

## Testing
- `npm test` *(fails: coverage below thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_6842103a3efc8328843d27d910418cb9