### PR TITLE
Validate export formats and add tests

### DIFF
--- a/src/parser/importHandler.ts
+++ b/src/parser/importHandler.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import logger from '../logging/logger';
 
 function isPathInsideWorkspace(filePath: string): boolean {
-    const folders = vscode.workspace.workspaceFolders;
+    const folders = vscode.workspace && vscode.workspace.workspaceFolders;
     if (!folders) {
         return true;
     }

--- a/src/parser/tactParser.ts
+++ b/src/parser/tactParser.ts
@@ -63,6 +63,7 @@ export async function parseTactContract(code: string): Promise<ContractGraph> {
                 }
             }
             while (i < tokens.length && tokens[i].type !== 'lparen') i++;
+            if (i >= tokens.length) break;
             i++; // skip '('
             const paramsStart = i;
             let depth = 0;
@@ -75,8 +76,10 @@ export async function parseTactContract(code: string): Promise<ContractGraph> {
                 i++;
             }
             const paramsEnd = i;
+            if (i >= tokens.length || tokens[i].type !== 'rparen') continue;
             i++; // skip ')'
             while (i < tokens.length && tokens[i].type !== 'lbrace') i++;
+            if (i >= tokens.length) break;
             i++; // skip '{'
             const bodyStart = i;
             depth = 1;
@@ -85,6 +88,7 @@ export async function parseTactContract(code: string): Promise<ContractGraph> {
                 else if (tokens[i].type === 'rbrace') depth--;
                 i++;
             }
+            if (depth !== 0) continue;
             const bodyEnd = i - 1;
             const params = tokens.slice(paramsStart, paramsEnd).map(t => t.value).join('');
             const bodyText = tokens.slice(bodyStart, bodyEnd).map(t => t.value).join('');

--- a/src/parser/tolkParser.ts
+++ b/src/parser/tolkParser.ts
@@ -131,6 +131,12 @@ export function extractBody(lines: string[], fromLine: number): { body: string; 
     let isAsm = false;
     for (let j = fromLine; j < lines.length; j++) {
         if (lines[j].includes('{')) {
+            const startLine = lines[j];
+            if (startLine.includes('}') && startLine.indexOf('{') < startLine.indexOf('}')) {
+                const match = /{([^}]*)}/.exec(startLine);
+                bodyText = match ? match[1] : '';
+                break;
+            }
             let braceCount = 1;
             const bodyLines: string[] = [];
             for (let k = j + 1; k < lines.length && braceCount > 0; k++) {
@@ -234,9 +240,6 @@ export async function parseTolkContract(code: string): Promise<ContractGraph> {
     for (const decl of declarations) {
         const { params, endLine } = parseParameters(lines, decl.lineIndex);
         const { body } = extractBody(lines, endLine);
-        if (!body.trim()) {
-            continue;
-        }
         const type = determineFunctionType(decl.isGet, decl.decorators);
         functions.set(decl.name, {
             id: decl.name,

--- a/test/exportHandler.test.ts
+++ b/test/exportHandler.test.ts
@@ -1,0 +1,169 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+function createPanel(expectedResponses: Record<string, any>, sentMessages: any[]) {
+    const panel: any = { webview: {} };
+    panel.webview.postMessage = async (msg: any) => {
+        sentMessages.push(msg);
+        if (msg.command === 'convertToPng' && expectedResponses['pngData']) {
+            setImmediate(() => {
+                panel.webview._listener?.(expectedResponses['pngData']);
+            });
+        } else if (msg.command === 'convertToJpg' && expectedResponses['jpgData']) {
+            setImmediate(() => {
+                panel.webview._listener?.(expectedResponses['jpgData']);
+            });
+        } else {
+            const resp = expectedResponses[msg.command];
+            if (resp) {
+                setImmediate(() => {
+                    panel.webview._listener?.(resp);
+                });
+            }
+        }
+        return true;
+    };
+    panel.webview.onDidReceiveMessage = (cb: any) => {
+        panel.webview._listener = cb;
+        return { dispose: () => {} };
+    };
+    panel.webview.asWebviewUri = (uri: any) => ({ toString: () => uri.fsPath });
+    return panel;
+}
+
+describe('exportHandler', () => {
+    let handleExport: any;
+
+    afterEach(() => {
+        mock.stopAll();
+        delete require.cache[require.resolve('../src/export/exportHandler')];
+        const paths = ['../src/parser/importHandler', '../src/parser/parserUtils'];
+        for (const p of paths) {
+            if (require.cache[require.resolve(p)]) {
+                delete require.cache[require.resolve(p)];
+            }
+        }
+    });
+
+    it('saves SVG when content is valid', async () => {
+        const tmp = path.join(os.tmpdir(), 'valid.svg');
+        let written: Buffer | undefined;
+        const messages: any[] = [];
+        mock('vscode', {
+            window: {
+                activeTextEditor: undefined,
+                showSaveDialog: async () => ({ fsPath: tmp }),
+                showInformationMessage: () => {},
+                showErrorMessage: () => {},
+                createOutputChannel: () => ({ appendLine: () => {} })
+            },
+            workspace: {
+                fs: {
+                    writeFile: async (_uri: any, data: any) => { written = Buffer.from(data); }
+                }
+            },
+            Uri: { file: (p: string) => ({ fsPath: p, toString() { return p; } }) }
+        });
+        handleExport = require('../src/export/exportHandler').handleExport;
+        const svg = '<svg></svg>';
+        const panel = createPanel({ getSvgContent: { command: 'svgContent', content: svg } }, messages);
+        await handleExport(panel, { command: 'saveSvg' }, { extensionPath: '.' });
+        expect(written?.toString()).to.equal(svg);
+        const result = messages.find(m => m.command === 'saveResult');
+        expect(result.success).to.be.true;
+        expect(result.type).to.equal('svg');
+    });
+
+    it('rejects invalid SVG content', async () => {
+        const tmp = path.join(os.tmpdir(), 'invalid.svg');
+        let written: Buffer | undefined;
+        const messages: any[] = [];
+        mock('vscode', {
+            window: {
+                activeTextEditor: undefined,
+                showSaveDialog: async () => ({ fsPath: tmp }),
+                showInformationMessage: () => {},
+                showErrorMessage: () => {},
+                createOutputChannel: () => ({ appendLine: () => {} })
+            },
+            workspace: {
+                fs: {
+                    writeFile: async (_uri: any, data: any) => { written = Buffer.from(data); }
+                }
+            },
+            Uri: { file: (p: string) => ({ fsPath: p, toString() { return p; } }) }
+        });
+        handleExport = require('../src/export/exportHandler').handleExport;
+        const panel = createPanel({ getSvgContent: { command: 'svgContent', content: 'bad' } }, messages);
+        await handleExport(panel, { command: 'saveSvg' }, { extensionPath: '.' });
+        expect(written).to.be.undefined;
+        const result = messages.find(m => m.command === 'saveResult');
+        expect(result.success).to.be.false;
+    });
+
+    it('saves PNG when base64 is valid', async () => {
+        const tmp = path.join(os.tmpdir(), 'out.png');
+        let written: Buffer | undefined;
+        const messages: any[] = [];
+        const pngData = 'data:image/png;base64,' + Buffer.from('png').toString('base64');
+        mock('vscode', {
+            window: {
+                activeTextEditor: undefined,
+                showSaveDialog: async () => ({ fsPath: tmp }),
+                showInformationMessage: () => {},
+                showErrorMessage: () => {},
+                createOutputChannel: () => ({ appendLine: () => {} })
+            },
+            workspace: {
+                fs: {
+                    writeFile: async (_uri: any, data: any) => { written = Buffer.from(data); }
+                }
+            },
+            Uri: { file: (p: string) => ({ fsPath: p, toString() { return p; } }) }
+        });
+        handleExport = require('../src/export/exportHandler').handleExport;
+        const panel = createPanel({
+            convertToPng: undefined,
+            pngData: { command: 'pngData', content: pngData }
+        }, messages);
+        // Need to respond to getSvgContent? actually function doesn't request - uses message.content only for validation
+        await handleExport(panel, { command: 'savePng', content: '<svg></svg>' }, { extensionPath: '.' });
+        expect(written).to.exist;
+        const result = messages.find(m => m.command === 'saveResult');
+        expect(result.success).to.be.true;
+        expect(result.type).to.equal('png');
+    });
+
+    it('rejects invalid PNG data url', async () => {
+        const tmp = path.join(os.tmpdir(), 'out.png');
+        let written: Buffer | undefined;
+        const messages: any[] = [];
+        mock('vscode', {
+            window: {
+                activeTextEditor: undefined,
+                showSaveDialog: async () => ({ fsPath: tmp }),
+                showInformationMessage: () => {},
+                showErrorMessage: () => {},
+                createOutputChannel: () => ({ appendLine: () => {} })
+            },
+            workspace: {
+                fs: {
+                    writeFile: async (_uri: any, data: any) => { written = Buffer.from(data); }
+                }
+            },
+            Uri: { file: (p: string) => ({ fsPath: p, toString() { return p; } }) }
+        });
+        handleExport = require('../src/export/exportHandler').handleExport;
+        const panel = createPanel({
+            convertToPng: undefined,
+            pngData: { command: 'pngData', content: 'data:image/png;base64,notbase64' }
+        }, messages);
+        await handleExport(panel, { command: 'savePng', content: '<svg></svg>' }, { extensionPath: '.' });
+        expect(written).to.be.undefined;
+        const result = messages.find(m => m.command === 'saveResult');
+        expect(result.success).to.be.false;
+    });
+});

--- a/test/importHandler.test.ts
+++ b/test/importHandler.test.ts
@@ -18,6 +18,10 @@ import {
 } from '../src/parser/importHandler';
 
 describe('ImportHandler', () => {
+    afterEach(() => {
+        mock.stopAll();
+        delete require.cache[require.resolve('../src/parser/importHandler')];
+    });
     it('rejects imports outside workspace', async () => {
         const code = '#include "../../etc/passwd"';
         const result = await processFuncImports(code, path.join(testRoot, 'dummy.fc'));

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -126,8 +126,12 @@ describe('Parser', () => {
         const main = path.join(tmp, 'main.fc');
         fs.writeFileSync(main, '#include "lib.fc"\nint main() { lib(); }');
         const code = fs.readFileSync(main, 'utf8');
-        const graph = await parseContractWithImports(code, main, 'func');
-        const ids = graph.nodes.map(n => n.id);
+        mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) }, workspace: { workspaceFolders: [{ uri: { fsPath: tmp } }] } });
+        delete require.cache[require.resolve('../src/parser/importHandler')];
+        delete require.cache[require.resolve('../src/parser/parserUtils')];
+        const { parseContractWithImports: parseWithImports } = require('../src/parser/parserUtils');
+        const graph = await parseWithImports(code, main, 'func');
+        const ids = graph.nodes.map((n: any) => n.id);
         expect(ids).to.include.members(['lib', 'main']);
     });
 });


### PR DESCRIPTION
## Summary
- validate SVG and base64 content in exportHandler
- add helper tests for exportHandler
- handle same-line braces in Tolk parser
- enforce invalid code detection in Tact parser
- update parser and import handler tests to clear vscode mocks

## Testing
- `npm test` *(fails: Coverage for lines (62.25%) does not meet global threshold (85%))*

------
https://chatgpt.com/codex/tasks/task_e_68421328e7588328af8ff85bef32805c