### PR TITLE
Improve coverage for parser utils and templates

### DIFF
--- a/test/importHandlerMissingFile.test.ts
+++ b/test/importHandlerMissingFile.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+import * as path from 'path';
+
+const tmpDir = __dirname;
+mock('vscode', {
+  window: { createOutputChannel: () => ({ appendLine: () => {} }) },
+  workspace: { workspaceFolders: [{ uri: { fsPath: tmpDir } }] }
+});
+
+import { processFuncImports } from '../src/parser/importHandler';
+
+describe('processFuncImports missing file', () => {
+  it('returns no imports when file missing', async () => {
+    const res = await processFuncImports('#include "nope.fc"', path.join(tmpDir, 'a.fc'));
+    expect(res.importedFilePaths.length).to.equal(0);
+    expect(res.importedCode).to.equal('');
+  });
+});

--- a/test/parserUtilsWithImports.test.ts
+++ b/test/parserUtilsWithImports.test.ts
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+
+// mock vscode minimal
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+
+let calledWith: any;
+const processImportsStub = async (...args: any[]) => {
+  calledWith = args;
+  return { importedCode: 'int lib() { return 1; }', importedFilePaths: [], cycles: [] };
+};
+mock('../src/parser/importHandler', { processImports: processImportsStub });
+
+const parserUtils = require('../src/parser/parserUtils');
+
+describe('parserUtils.parseContractWithImports', () => {
+  after(() => {
+    mock.stop('../src/parser/importHandler');
+  });
+
+  it('combines imported code before parsing', async () => {
+    let parseArgs: any;
+    parserUtils.parseContractByLanguage = async (code: string, lang: string) => { parseArgs = [code, lang]; return { nodes: [], edges: [] }; };
+
+    await parserUtils.parseContractWithImports('int main(){}', '/tmp/main.fc', 'func');
+
+    expect(calledWith).to.deep.equal(['int main(){}', '/tmp/main.fc', 'func']);
+    expect(parseArgs).to.deep.equal(['int lib() { return 1; }\n\nint main(){}', 'func']);
+  });
+});

--- a/test/templates.test.ts
+++ b/test/templates.test.ts
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import { generateErrorHtml, filterMermaidDiagram } from '../src/visualization/templates';
+
+describe('templates utilities', () => {
+  it('escapes error message in HTML', () => {
+    const html = generateErrorHtml('<tag>');
+    expect(html).to.include('&lt;tag&gt;');
+    expect(html).to.include('Error Occurred');
+  });
+
+  it('filters nodes by type', () => {
+    const diagram = 'graph TB;\nA_impure["A"]\nB_regular["B"]\nA_impure --> B_regular';
+    const out = filterMermaidDiagram(diagram, ['regular']);
+    expect(out).to.include('B_regular');
+    expect(out).not.to.include('A_impure["A"]');
+  });
+
+  it('filters by name but keeps connected nodes', () => {
+    const diagram = 'graph TB;\nA_impure["A"]\nB_regular["B"]\nA_impure --> B_regular';
+    const out = filterMermaidDiagram(diagram, ['impure', 'regular'], 'A');
+    expect(out).to.include('A_impure');
+    expect(out).to.include('B_regular');
+  });
+
+  it('removes duplicate graph directives', () => {
+    const invalid = 'graph TB;\nsubgraph X\n graph LR;\n A_impure --> B_regular\nend';
+    const out = filterMermaidDiagram(invalid, ['impure', 'regular']);
+    expect(out.match(/graph /g)?.length).to.equal(1);
+  });
+});

--- a/test/visualizerError.test.ts
+++ b/test/visualizerError.test.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+
+let received: any;
+const messages: any[] = [];
+const panelStub = {
+  webview: {
+    html: '',
+    asWebviewUri: (uri: any) => ({ toString: () => uri.fsPath }),
+    onDidReceiveMessage: (cb: any) => { received = cb; },
+    postMessage: (msg: any) => { messages.push(msg); return Promise.resolve(true); }
+  },
+  onDidDispose: () => {}
+};
+
+mock('vscode', {
+  window: {
+    createWebviewPanel: () => panelStub,
+    showErrorMessage: () => {},
+    createOutputChannel: () => ({ appendLine: () => {} })
+  },
+  ViewColumn: { Beside: 1 },
+  Uri: { file: (p: string) => ({ fsPath: p, toString() { return p; } }) }
+});
+
+mock('../src/visualization/templates', {
+  generateVisualizationHtml: () => 'html',
+  filterMermaidDiagram: () => { throw new Error('bad'); }
+});
+
+const { createVisualizationPanel } = require('../src/visualization/visualizer');
+
+describe('createVisualizationPanel error handling', () => {
+  after(() => {
+    mock.stop('../src/visualization/templates');
+  });
+
+  it('handles errors during filtering gracefully', async () => {
+    const context = { extensionPath: process.cwd(), subscriptions: [] } as any;
+    createVisualizationPanel(context, { nodes: [], edges: [] }, []);
+    await new Promise(r => setTimeout(r, 0));
+    if (typeof received === 'function') {
+      expect(() => received({ command: 'applyFilters', selectedTypes: [] })).not.to.throw();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for parser utils with import handling
- cover missing FunC import case in import handler
- cover visualization templates and error handling
- ensure visualizer handles filter errors gracefully

## Testing
- `npm test` *(fails due to coverage thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_6842239252d4832896532ccb0fd16727