### PR TITLE
Fix module mock path in parser utils test

### DIFF
--- a/test/parserUtilsWithImports.test.ts
+++ b/test/parserUtilsWithImports.test.ts
@@ -9,13 +9,13 @@ const processImportsStub = async (...args: any[]) => {
   calledWith = args;
   return { importedCode: 'int lib() { return 1; }', importedFilePaths: [], cycles: [] };
 };
-mock('../src/parser/importHandler', { processImports: processImportsStub });
+mock('../src/parser/importHandler.ts', { processImports: processImportsStub });
 
 const parserUtils = require('../src/parser/parserUtils');
 
 describe('parserUtils.parseContractWithImports', () => {
   after(() => {
-    mock.stop('../src/parser/importHandler');
+    mock.stop('../src/parser/importHandler.ts');
   });
 
   it('combines imported code before parsing', async () => {


### PR DESCRIPTION
## Summary
- adjust mock path in `parserUtilsWithImports` test to include `.ts` extension

## Testing
- `npm test` *(fails: 4 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68427fcadd248328800e91c13c2d7e51