### PR TITLE
Handle missing panel graph in message handler

### DIFF
--- a/src/visualization/visualizer.ts
+++ b/src/visualization/visualizer.ts
@@ -72,10 +72,29 @@ export function createVisualizationPanel(
         message => {
             try {
                 if (message.command === 'applyFilters') {
-                    const mermaidUri = bundledMermaidUri ? panel.webview.asWebviewUri(bundledMermaidUri).toString() : '';
-                    handleFilterRequest(panel, message.selectedTypes, mermaidUri, message.nameFilter);
-                } else if (message.command === 'saveMermaid' || message.command === 'saveSvg' ||
-                    message.command === 'savePng' || message.command === 'saveJpg') {
+                    if (!panelGraphs.get(panel)) {
+                        panel.webview.postMessage({
+                            command: 'filterError',
+                            error: 'Original graph not found for this panel.'
+                        });
+                        return;
+                    }
+
+                    const mermaidUri = bundledMermaidUri
+                        ? panel.webview.asWebviewUri(bundledMermaidUri).toString()
+                        : '';
+                    handleFilterRequest(
+                        panel,
+                        message.selectedTypes,
+                        mermaidUri,
+                        message.nameFilter
+                    );
+                } else if (
+                    message.command === 'saveMermaid' ||
+                    message.command === 'saveSvg' ||
+                    message.command === 'savePng' ||
+                    message.command === 'saveJpg'
+                ) {
                     // Handle other messages (export commands, etc.)
                 }
             } catch (error) {

--- a/test/visualizerNoGraph.test.ts
+++ b/test/visualizerNoGraph.test.ts
@@ -50,6 +50,6 @@ describe('visualizer missing graph handling', () => {
     }
     const errMsg = messages.find(m => m.command === 'filterError');
     expect(errMsg).to.exist;
-    expect(errMsg.error).to.match(/Original graph not found/);
+    expect(errMsg.error).to.equal('Original graph not found for this panel.');
   });
 });


### PR DESCRIPTION
## Summary
- return a filter error when panel graph is missing
- check for specific error message in `visualizerNoGraph` test

## Testing
- `npx mocha -r ts-node/register test/visualizerNoGraph.test.ts`
- `npm test` *(fails: parserUtils.parseContractWithImports, visualizerNoGraph)*

------
https://chatgpt.com/codex/tasks/task_e_6842874492f083288f1ef157739191e2