### PR TITLE
Fix logger path redaction

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -5,6 +5,18 @@ import * as vscode from 'vscode';
 import { Writable } from 'stream';
 
 const sanitizeFormat = format((info) => {
+  function redactPaths(text: string): string {
+    return text
+      .split(/\s+/)
+      .map(part => {
+        const cleaned = part.replace(/['"`]/g, '');
+        return path.isAbsolute(cleaned) || path.win32.isAbsolute(cleaned)
+          ? '[REDACTED_PATH]'
+          : part;
+      })
+      .join(' ');
+  }
+
   const sanitize = (value: any): any => {
     if (value && typeof value === 'object') {
       for (const k of Object.keys(value)) {
@@ -17,8 +29,7 @@ const sanitizeFormat = format((info) => {
       return value;
     }
     if (typeof value === 'string') {
-      const pathPattern = /(?:[A-Za-z]:)?[\\/][^\s]+/g;
-      value = value.replace(pathPattern, '[REDACTED_PATH]');
+      value = redactPaths(value);
       const apiKeyPattern = /(api[_-]?key\s*[=:]\s*)([^\s]+)/i;
       return value.replace(apiKeyPattern, '$1[FILTERED]');
     }

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -37,4 +37,12 @@ describe('Logger', () => {
     expect(last).to.not.include('SECRET');
     expect(last).to.not.include('/tmp/secret.txt');
   });
+
+  it('redacts absolute paths with spaces and quotes', () => {
+    logger.info('opening "C:\\Secret Folder\\file.txt"');
+    logger.info("processing '/tmp/some file '");
+    const lastTwo = outputChannel.messages.slice(-2);
+    expect(lastTwo[0]).to.not.include('C:\\Secret Folder\\file.txt');
+    expect(lastTwo[1]).to.not.include('/tmp/some file');
+  });
 });


### PR DESCRIPTION
## Summary
- improve logging sanitization by redacting absolute paths via function
- test path redaction on quoted/space-separated paths

## Testing
- `npm test` *(fails: exportHandler, parserUtilsWithImports, visualizerNoGraph)*

------
https://chatgpt.com/codex/tasks/task_e_68429660214883288883f39749c01a3d