### PR TITLE
Improve Tolk parser tests

### DIFF
--- a/src/parser/tolkParser.ts
+++ b/src/parser/tolkParser.ts
@@ -71,7 +71,6 @@ export function findFunctionDeclarations(lines: string[], globalVariables: Set<s
 
             const decorators = new Set<string>();
             const currentLine = lines[i];
-            const prevLine = i > 0 ? lines[i - 1] : '';
 
             let decoratorMatch: RegExpExecArray | null;
             const decoratorRegex = /@([a-zA-Z_]+)/g;
@@ -79,11 +78,13 @@ export function findFunctionDeclarations(lines: string[], globalVariables: Set<s
                 decorators.add(decoratorMatch[1]);
             }
 
-            if (prevLine.trim().startsWith('@') && !prevLine.includes('fun')) {
-                const prevDecorators = prevLine.match(/@([a-zA-Z_]+)/g) || [];
+            let prevIndex = i - 1;
+            while (prevIndex >= 0 && lines[prevIndex].trim().startsWith('@') && !lines[prevIndex].includes('fun')) {
+                const prevDecorators = lines[prevIndex].match(/@([a-zA-Z_]+)/g) || [];
                 for (const dec of prevDecorators) {
                     decorators.add(dec.substring(1));
                 }
+                prevIndex--;
             }
 
             if (BUILT_IN_FUNCTIONS.has(funcName) || globalVariables.has(funcName)) {

--- a/test/tolkParserFunctions.test.ts
+++ b/test/tolkParserFunctions.test.ts
@@ -55,4 +55,50 @@ describe('Tolk parser helper functions', () => {
         const edges = analyzeFunctionCalls(functions);
         expect(edges).to.deep.include({ from: 'foo', to: 'bar', label: '' });
     });
+
+    it('ignores built-in function declarations', () => {
+        const code = 'fun foo() { sendRawMessage(); }\nfun sendRawMessage() {}';
+        const linesBuiltIn = code.split('\n');
+        const decls = findFunctionDeclarations(linesBuiltIn, new Set());
+        const names = decls.map(d => d.name);
+        expect(names).to.include('foo');
+        expect(names).to.not.include('sendRawMessage');
+    });
+
+    it('handles multi-line decorators', () => {
+        const code = '@pure\n@inline\nfun deco() {}';
+        const linesDecorators = code.split('\n');
+        const decls = findFunctionDeclarations(linesDecorators, new Set());
+        const deco = decls.find(d => d.name === 'deco')!;
+        expect(Array.from(deco.decorators)).to.have.members(['pure', 'inline']);
+    });
+
+    it('skips commented-out calls and semicolon-prefixed calls', () => {
+        const source = `fun foo() {\n    //bar();\n    bar();\n    x = 1; baz();\n}\nfun bar() {}\nfun baz() {}`;
+        const callLines = source.split('\n');
+        const decls = findFunctionDeclarations(callLines, new Set());
+        const functions = new Map<string, TolkFunctionInfo>();
+        for (const d of decls) {
+            const { params, endLine } = parseParameters(callLines, d.lineIndex);
+            const { body } = extractBody(callLines, endLine);
+            functions.set(d.name, {
+                id: d.name,
+                params,
+                body,
+                decorators: d.decorators,
+                isGet: d.isGet,
+                type: determineFunctionType(d.isGet, d.decorators)
+            });
+        }
+        const edges = analyzeFunctionCalls(functions);
+        expect(edges).to.deep.include({ from: 'foo', to: 'bar', label: '' });
+        expect(edges.some(e => e.to === 'baz')).to.be.false;
+    });
+
+    it('determines all function types', () => {
+        expect(determineFunctionType(true, new Set())).to.equal('get');
+        expect(determineFunctionType(false, new Set(['pure']))).to.equal('pure_fun');
+        expect(determineFunctionType(false, new Set(['inline']))).to.equal('inline_fun');
+        expect(determineFunctionType(false, new Set(['pure', 'inline']))).to.equal('pure_fun');
+    });
 });


### PR DESCRIPTION
## Summary
- cover multi-line decorators in Tolk parser
- ignore built-in Tolk functions in parsing
- exercise comment and semicolon branches in function call analysis
- test all branches of `determineFunctionType`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68429d54fef083288dc8970d00674c1a