### PR TITLE
Add toncenter caching test

### DIFF
--- a/test/toncenter.test.ts
+++ b/test/toncenter.test.ts
@@ -78,4 +78,21 @@ describe('callToncenter', () => {
             expect(elapsed).to.be.greaterThan(290);
         }
     });
+
+    it('caches successful responses', async () => {
+        let calls = 0;
+        server.use(
+            rest.get('https://toncenter.com/api/v2/', (_req, res, ctx) => {
+                calls++;
+                return res(ctx.json({ ok: true }));
+            })
+        );
+        const context = { workspaceState: new TestMemento(), secrets: new TestSecrets() } as any;
+        const result1 = await callToncenter(context, 'test', { q: 1 });
+        expect(result1).to.deep.equal({ ok: true });
+        expect(calls).to.equal(1);
+        const result2 = await callToncenter(context, 'test', { q: 1 });
+        expect(result2).to.deep.equal({ ok: true });
+        expect(calls).to.equal(1);
+    });
 });


### PR DESCRIPTION
## Summary
- test toncenter to confirm caching of successful responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842a22138d8832899d7b86fc338f2e6