### PR TITLE
Add tokenManager key tests

### DIFF
--- a/test/tokenManager.test.ts
+++ b/test/tokenManager.test.ts
@@ -17,6 +17,21 @@ class TestSecrets {
 }
 
 describe('tokenManager', () => {
+    it('stores and retrieves the API key', async () => {
+        const context = { secrets: new TestSecrets() } as any;
+        await setApiKey(context, 'SECRET');
+        const value = await getApiKey(context);
+        expect(value).to.equal('SECRET');
+    });
+
+    it('overwrites the stored API key when updated', async () => {
+        const context = { secrets: new TestSecrets() } as any;
+        await setApiKey(context, 'OLD_SECRET');
+        await setApiKey(context, 'NEW_SECRET');
+        const value = await getApiKey(context);
+        expect(value).to.equal('NEW_SECRET');
+    });
+
     it('removes the stored API key', async () => {
         const context = { secrets: new TestSecrets() } as any;
         await setApiKey(context, 'SECRET');


### PR DESCRIPTION
## Summary
- add tests for storing and retrieving API keys
- check overwriting existing key

## Testing
- `npm test` *(fails: exportHandler, parserUtilsWithImports, visualizer, visualizerNoGraph)*

------
https://chatgpt.com/codex/tasks/task_e_6842a38b20b8832895bb5b3c52b89994