### PR TITLE
Add activation tests

### DIFF
--- a/test/extensionActivate.test.ts
+++ b/test/extensionActivate.test.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+
+
+describe('extension activate', () => {
+    afterEach(() => {
+        mock.stopAll();
+        delete require.cache[require.resolve('../src/extension')];
+    });
+
+    it('registers commands and ignores directory errors', () => {
+        const registered: string[] = [];
+        let dirCalled = false;
+        mock('vscode', {
+            commands: {
+                registerCommand: (cmd: string, cb: any) => {
+                    registered.push(cmd);
+                    return { dispose: () => {} };
+                }
+            },
+            workspace: {
+                fs: {
+                    createDirectory: () => {
+                        dirCalled = true;
+                        throw new Error('fail');
+                    }
+                }
+            },
+            window: { showInputBox: () => {}, showInformationMessage: () => {} },
+            Uri: { file: (p: string) => ({ fsPath: p, toString() { return p; } }) }
+        });
+
+        const context = { extensionPath: '.', subscriptions: [] } as any;
+        const { activate } = require('../src/extension');
+        expect(() => activate(context)).to.not.throw();
+        expect(dirCalled).to.be.true;
+        expect(registered).to.deep.equal([
+            'ton-graph.visualize',
+            'ton-graph.visualizeProject',
+            'ton-graph.setApiKey',
+            'ton-graph.deleteApiKey'
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
- test for extension activation
- verify commands register
- ignore createDirectory failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842aeb87e1c8328a8c4726f07162da9