### PR TITLE
Update VS Code engine and clean activation events

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ You can also view logs directly in VS Code under **Output** → **TON Graph**.
 
 ## Requirements
 
-- Visual Studio Code 1.60.0 or newer
+ - Visual Studio Code 1.75.0 or newer
 
 ## Known Issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/moo": "^0.5.10",
         "@types/node": "^18.x.x",
         "@types/node-fetch": "^2.6.12",
-        "@types/vscode": "^1.60.0",
+        "@types/vscode": "^1.75.0",
         "@typescript-eslint/eslint-plugin": "^4.x.x",
         "@typescript-eslint/parser": "^4.x.x",
         "@vscode/vsce": "^3.5.0",
@@ -49,7 +49,7 @@
         "vscode": "^1.1.37"
       },
       "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.75.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -15,20 +15,11 @@
   },
   "homepage": "https://github.com/PositiveSecurity/ton-graph",
   "engines": {
-    "vscode": "^1.60.0"
+    "vscode": "^1.75.0"
   },
   "categories": [
     "Visualization",
     "Programming Languages"
-  ],
-  "activationEvents": [
-    "onCommand:ton-graph.visualize",
-    "onCommand:ton-graph.visualizeProject",
-    "onCommand:ton-graph.setApiKey",
-    "onCommand:ton-graph.deleteApiKey",
-    "onLanguage:func",
-    "onLanguage:tact",
-    "onLanguage:tolk"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -150,7 +141,7 @@
     "@types/moo": "^0.5.10",
     "@types/node": "^18.x.x",
     "@types/node-fetch": "^2.6.12",
-    "@types/vscode": "^1.60.0",
+    "@types/vscode": "^1.75.0",
     "@typescript-eslint/eslint-plugin": "^4.x.x",
     "@typescript-eslint/parser": "^4.x.x",
     "@vscode/vsce": "^3.5.0",


### PR DESCRIPTION
## Summary
- target VS Code engine ^1.75.0
- remove explicit activation events
- update @types/vscode dependency
- document the new VS Code requirement

## Testing
- `npm ci`
- `npm test` *(fails: 105 passing, 9 failing)*

------
https://chatgpt.com/codex/tasks/task_e_6842f72faae883289d1e693bc51bbbc5