### PR TITLE
Improve logging for context menu commands

### DIFF
--- a/src/commands/visualizeProject.ts
+++ b/src/commands/visualizeProject.ts
@@ -9,24 +9,28 @@ import { applyFilters } from './filterUtils';
 let panel: vscode.WebviewPanel | undefined;
 
 export async function visualizeProject(context: vscode.ExtensionContext, fileUri?: vscode.Uri) {
+    logger.info(`visualizeProject command started with ${fileUri?.fsPath ?? 'active editor'}`);
     let document: vscode.TextDocument;
     let code: string;
     let filePath: string;
 
     if (fileUri) {
         try {
+            logger.debug(`Reading file ${fileUri.fsPath}`);
             const fileData = await vscode.workspace.fs.readFile(fileUri);
             code = Buffer.from(fileData).toString('utf8');
             filePath = fileUri.fsPath;
             document = await vscode.workspace.openTextDocument(fileUri);
         } catch (error: any) {
             vscode.window.showErrorMessage(`Could not read file: ${error.message || String(error)}`);
+            logger.error('Failed to read file', error);
             return;
         }
     } else {
         const editor = vscode.window.activeTextEditor;
         if (!editor) {
             vscode.window.showErrorMessage('No active editor found');
+            logger.error('No active editor found');
             return;
         }
         document = editor.document;
@@ -42,9 +46,11 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
         }, async (progress) => {
             progress.report({ increment: 20, message: 'Detecting language...' });
             const language = detectLanguage(filePath);
+            logger.debug(`Detected language ${language}`);
 
             progress.report({ increment: 30, message: 'Processing imports...' });
             let originalGraph = await parseContractWithImports(code, filePath, language);
+            logger.debug('Parsed contract with imports');
 
             progress.report({ increment: 30, message: 'Generating visualization...' });
             if (panel) {
@@ -52,6 +58,7 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
             }
 
             panel = createVisualizationPanel(context, originalGraph, getFunctionTypeFilters(language), 'Contract Project Visualization');
+            logger.debug('Visualization panel created');
 
             panel.onDidDispose(() => {
                 panel = undefined;
@@ -62,8 +69,10 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
                     if (message.command === 'applyFilters') {
                         const selectedTypes = message.selectedTypes as string[];
                         const nameFilter = message.nameFilter ? message.nameFilter.trim().toLowerCase() : '';
+                        logger.debug(`Applying filters types=${selectedTypes.join(',')} name=${nameFilter}`);
                         applyFilters(panel!, originalGraph, selectedTypes, nameFilter);
                     } else {
+                        logger.debug(`Handling export command ${message.command}`);
                         await handleExport(panel!, message, context);
                     }
                 },
@@ -73,6 +82,8 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
 
             progress.report({ increment: 20, message: 'Opening visualization...' });
             panel!.reveal(vscode.ViewColumn.Beside);
+            logger.debug('Visualization panel revealed');
+            logger.info('visualizeProject command completed successfully');
         });
     } catch (error: any) {
         logger.error('Error visualizing contract project', error);

--- a/src/export/exportHandler.ts
+++ b/src/export/exportHandler.ts
@@ -35,6 +35,7 @@ export async function handleExport(
     context: vscode.ExtensionContext
 ): Promise<void> {
     try {
+        logger.info(`handleExport received command ${message.command}`);
         // Get the current file name without extension
         const editor = vscode.window.activeTextEditor;
         let baseFileName = "diagram";
@@ -50,18 +51,23 @@ export async function handleExport(
 
         switch (message.command) {
             case 'saveMermaid':
+                logger.debug('Exporting Mermaid diagram');
                 await handleMermaidExport(panel, message, baseFileName, basePath);
                 break;
             case 'saveSvg':
+                logger.debug('Exporting SVG diagram');
                 await handleSvgExport(panel, message, baseFileName, basePath);
                 break;
             case 'savePng':
+                logger.debug('Exporting PNG diagram');
                 await handlePngExport(panel, message, baseFileName, basePath);
                 break;
             case 'saveJpg':
+                logger.debug('Exporting JPG diagram');
                 await handleJpgExport(panel, message, baseFileName, basePath);
                 break;
             case 'applyFilters':
+                logger.debug('Applying filters via export handler');
                 await handleApplyFilters(panel, message, context);
                 break;
             case 'mermaidContent':
@@ -88,6 +94,7 @@ async function handleApplyFilters(
     context: vscode.ExtensionContext
 ): Promise<void> {
     try {
+        logger.info('Applying filters from export handler');
         const { selectedTypes, nameFilter } = message;
 
         // Get original graph content
@@ -137,6 +144,7 @@ async function handleApplyFilters(
                 selectedTypes,
                 nameFilter
             });
+            logger.info('Filters applied successfully');
         } catch (updateError) {
             logger.error('Error updating webview content', updateError);
             throw updateError;
@@ -181,6 +189,7 @@ async function handleMermaidExport(
     baseFileName: string,
     basePath: string
 ): Promise<void> {
+    logger.info('Starting Mermaid export');
     // Get the current diagram content from the webview
     panel.webview.postMessage({ command: 'getMermaidContent' });
 
@@ -208,6 +217,7 @@ async function handleMermaidExport(
         const data = encoder.encode(mermaidContent);
         await vscode.workspace.fs.writeFile(mermaidUri, data);
         vscode.window.showInformationMessage('Mermaid diagram saved successfully!');
+        logger.info(`Mermaid diagram saved at ${mermaidUri.fsPath}`);
         panel.webview.postMessage({
             command: 'saveResult',
             success: true,
@@ -223,6 +233,7 @@ async function handleSvgExport(
     baseFileName: string,
     basePath: string
 ): Promise<void> {
+    logger.info('Starting SVG export');
     // Get the current SVG content from the webview
     panel.webview.postMessage({ command: 'getSvgContent' });
 
@@ -255,6 +266,7 @@ async function handleSvgExport(
         const data = encoder.encode(svgContent);
         await vscode.workspace.fs.writeFile(svgUri, data);
         vscode.window.showInformationMessage('SVG diagram saved successfully!');
+        logger.info(`SVG diagram saved at ${svgUri.fsPath}`);
         panel.webview.postMessage({
             command: 'saveResult',
             success: true,
@@ -270,6 +282,7 @@ async function handlePngExport(
     baseFileName: string,
     basePath: string
 ): Promise<void> {
+    logger.info('Starting PNG export');
     // Show save dialog first
     const pngUri = await vscode.window.showSaveDialog({
         defaultUri: vscode.Uri.file(path.join(basePath, `${baseFileName}.png`)),
@@ -346,6 +359,7 @@ async function handleJpgExport(
     baseFileName: string,
     basePath: string
 ): Promise<void> {
+    logger.info('Starting JPG export');
     // Show save dialog first
     const jpgUri = await vscode.window.showSaveDialog({
         defaultUri: vscode.Uri.file(path.join(basePath, `${baseFileName}.jpg`)),
@@ -402,6 +416,7 @@ async function handleJpgExport(
 
             await vscode.workspace.fs.writeFile(jpgUri, jpgBinary);
             vscode.window.showInformationMessage('JPG diagram saved successfully!');
+            logger.info(`JPG diagram saved at ${jpgUri.fsPath}`);
             panel.webview.postMessage({
                 command: 'saveResult',
                 success: true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,44 +2,57 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { visualize, visualizeProject } from './commands';
 import { setApiKey, deleteApiKey } from './secrets/tokenManager';
+import logger from './logging/logger';
 
 export function activate(context: vscode.ExtensionContext) {
+    logger.info('Activating TON Graph extension');
     const cachedDir = vscode.Uri.file(path.join(context.extensionPath, 'cached'));
     try {
         vscode.workspace.fs.createDirectory(cachedDir);
+        logger.debug(`Created cached directory at ${cachedDir.fsPath}`);
     } catch (err) {
         // Directory might already exist, that's fine
+        logger.debug('Cached directory already exists');
     }
 
     context.subscriptions.push(
         vscode.commands.registerCommand('ton-graph.visualize', async (fileUri?: vscode.Uri) => {
+            logger.info(`Command visualize triggered with ${fileUri?.fsPath ?? 'no file'}`);
             await visualize(context, fileUri);
         })
     );
 
     context.subscriptions.push(
         vscode.commands.registerCommand('ton-graph.visualizeProject', async (fileUri?: vscode.Uri) => {
+            logger.info(`Command visualizeProject triggered with ${fileUri?.fsPath ?? 'no file'}`);
             await visualizeProject(context, fileUri);
         })
     );
 
     const apiKeyDisposable = vscode.commands.registerCommand('ton-graph.setApiKey', async () => {
+        logger.info('Set API key command triggered');
         const value = await vscode.window.showInputBox({
             prompt: 'Enter TON API key',
             ignoreFocusOut: true,
         });
         if (value !== undefined) {
             await setApiKey(context, value.trim());
+            logger.info('API key saved');
             vscode.window.showInformationMessage('TON Graph API key saved');
         }
     });
 
     const deleteApiKeyDisposable = vscode.commands.registerCommand('ton-graph.deleteApiKey', async () => {
+        logger.info('Delete API key command triggered');
         await deleteApiKey(context);
         vscode.window.showInformationMessage('TON Graph API key deleted');
+        logger.info('API key deleted');
     });
 
     context.subscriptions.push(apiKeyDisposable, deleteApiKeyDisposable);
+    logger.info('TON Graph extension activated');
 }
 
-export function deactivate() {}
+export function deactivate() {
+    logger.info('TON Graph extension deactivated');
+}

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -65,7 +65,7 @@ const outputStream = new Writable({
 });
 
 const logger = createLogger({
-  level: 'info',
+  level: process.env.TON_GRAPH_LOG_LEVEL || 'debug',
   format: logFormat,
   transports: [
     new transports.File({


### PR DESCRIPTION
## Summary
- set default log level to `debug`
- add info/debug messages in extension activation and commands
- log export operations in detail

## Testing
- `npm test` *(fails: AssertionError and type errors)*
- `npm run lint` *(fails with lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842fa9375248328a910a42d887c0838