### PR TITLE
Fix failing Playwright tests

### DIFF
--- a/playwright/webview.test.ts
+++ b/playwright/webview.test.ts
@@ -22,7 +22,7 @@ test('webview contains mermaid', async () => {
     ]
   });
 
-  expect(exitCode).toBeUndefined();
+  expect(exitCode).toBe(0);
 });
 
 test('graph screenshot matches golden', async ({ page }, testInfo) => {
@@ -44,7 +44,7 @@ test('graph screenshot matches golden', async ({ page }, testInfo) => {
     testRunnerEnv: { OUTPUT_HTML: htmlPath }
   });
 
-  expect(exitCode).toBeUndefined();
+  expect(exitCode).toBe(0);
 
   await page.goto('file://' + htmlPath);
   await page.waitForSelector('.mermaid svg');

--- a/playwright/xss.test.ts
+++ b/playwright/xss.test.ts
@@ -19,5 +19,5 @@ test('malicious names are sanitized', async () => {
     ]
   });
 
-  expect(exitCode).toBeUndefined();
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary
- expect zero exit codes from `runTests`

## Testing
- `npm run test:playwright` *(fails: spawn VS Code ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6842ff37e7f08328961cf44cde6c634b