### PR TITLE
Fix extension activation from context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,16 @@
     "Programming Languages"
   ],
   "main": "./out/extension.js",
+  "activationEvents": [
+    "onCommand:ton-graph.visualize",
+    "onCommand:ton-graph.visualizeProject",
+    "onCommand:ton-graph.saveMermaid",
+    "onCommand:ton-graph.saveSvg",
+    "onCommand:ton-graph.savePng",
+    "onCommand:ton-graph.saveJpg",
+    "onCommand:ton-graph.setApiKey",
+    "onCommand:ton-graph.deleteApiKey"
+  ],
   "contributes": {
     "languages": [
       {


### PR DESCRIPTION
## Summary
- activate extension on command invocations to ensure logging works when context menu actions run

## Testing
- `npm test` *(fails: 9 failing)*
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_6843006d8c8c832888f22abd0016156a