### PR TITLE
feat: architecture refactor + initial Move support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,15 @@
 
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 
-A Visual Studio Code extension for visualizing function call graphs in TON smart contracts written in FunC, Tact, and Tolk.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk and Move.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr01.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr01.jpg" width="400" alt="TON Graph visualization">
+</a>
+<a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr05.jpg" target="_blank">
+  <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr05.jpg" width="400" alt="Move call graph">
 </a>
 
 ## Features
@@ -16,6 +19,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - FunC (*.fc, *.func)
   - Tact (*.tact)
   - Tolk (*.tolk)
+  - Move (*.move)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -40,10 +44,11 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 3. Search for "TON Graph"
 4. Click Install
 5. Run "TON Graph: Set API Key" from the command palette and enter your Toncenter API key
+6. Install the `move-analyzer` binary and ensure it is available in your PATH
 
 ## Usage
 
-1. Open a contract file (*.fc, *.func, *.tact, or *.tolk)
+1. Open a contract file (*.fc, *.func, *.tact, *.tolk, or *.move)
 2. You can visualize a contract in multiple ways:
    - Press F1 or Ctrl+Shift+P to open the command palette and type "TON Graph: Visualize Contract"
    - Right-click on contract code in the editor → TON Graph: Visualize Contract

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dompurify": "^3.2.6",
         "mermaid": "^11.6.0",
         "moo": "^0.5.2",
+        "vscode-languageclient": "^9.0.1",
         "web-tree-sitter": "^0.25.6",
         "winston": "^3.17.0"
       },
@@ -3774,7 +3775,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -11710,7 +11710,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12977,6 +12976,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^5.1.0",
+        "semver": "^7.3.7",
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/vscode-languageserver": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,11 @@
     "onCommand:ton-graph.savePng",
     "onCommand:ton-graph.saveJpg",
     "onCommand:ton-graph.setApiKey",
-    "onCommand:ton-graph.deleteApiKey"
+    "onCommand:ton-graph.deleteApiKey",
+    "onLanguage:func",
+    "onLanguage:tact",
+    "onLanguage:tolk",
+    "onLanguage:move"
   ],
   "contributes": {
     "languages": [
@@ -60,6 +64,15 @@
         ],
         "aliases": [
           "Func"
+        ]
+      },
+      {
+        "id": "move",
+        "extensions": [
+          ".move"
+        ],
+        "aliases": [
+          "Move"
         ]
       }
     ],
@@ -178,7 +191,8 @@
     "mermaid": "^11.6.0",
     "moo": "^0.5.2",
     "web-tree-sitter": "^0.25.6",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "vscode-languageclient": "^9.0.1"
   },
   "files": [
     "out/**/*",

--- a/src/core/graphProvider.ts
+++ b/src/core/graphProvider.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+import { LanguageAdapter, AST } from './types';
+
+export class GraphProvider implements vscode.DocumentSymbolProvider {
+  constructor(private adapter: LanguageAdapter) {}
+
+  provideDocumentSymbols(document: vscode.TextDocument): vscode.ProviderResult<vscode.DocumentSymbol[]> {
+    const ast = this.adapter.parse(document.getText()) as any;
+    if (!('functions' in ast)) {
+      return [];
+    }
+    const symbols: vscode.DocumentSymbol[] = [];
+    (ast as any).functions.forEach((fn: any) => {
+      const symbol = new vscode.DocumentSymbol(
+        fn.name,
+        '',
+        vscode.SymbolKind.Function,
+        new vscode.Range(0, 0, 0, 0),
+        new vscode.Range(0, 0, 0, 0)
+      );
+      symbols.push(symbol);
+    });
+    return symbols;
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,7 @@
+export interface AST { /* generic */ }
+export interface Edge { from: string; to: string; label?: string; }
+export interface LanguageAdapter {
+  readonly fileExtensions: string[];
+  parse(source: string): AST;
+  buildCallGraph(ast: AST): Edge[];
+}

--- a/src/languages/func/funcParser.ts
+++ b/src/languages/func/funcParser.ts
@@ -2,8 +2,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as WebTreeSitter from 'web-tree-sitter';
 import { loadFunC } from '@scaleton/tree-sitter-func';
-import { ContractGraph, ContractNode } from '../types/graph';
-import { GraphNodeKind } from '../types/graphNodeKind';
+import { ContractGraph, ContractNode } from '../../types/graph';
+import { GraphNodeKind } from '../../types/graphNodeKind';
 
 const BUILT_IN_FUNCTIONS = new Set([
     'if', 'elseif', 'while', 'for', 'switch', 'return', 'throw', 'throw_unless',

--- a/src/languages/func/importHandler.ts
+++ b/src/languages/func/importHandler.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import logger from '../logging/logger';
+import logger from '../../logging/logger';
 
 async function safeReadFile(filePath: string): Promise<string> {
     const handle = await fs.promises.open(filePath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);

--- a/src/languages/func/index.ts
+++ b/src/languages/func/index.ts
@@ -1,0 +1,37 @@
+import { AST, Edge, LanguageAdapter } from '../../core/types';
+import { parseContractCode } from './funcParser';
+import { parseTactContract } from './tactParser';
+import { parseTolkContract } from './tolkParser';
+
+const funcAdapter: LanguageAdapter = {
+  fileExtensions: ['.fc', '.func'],
+  parse(source: string): AST {
+    return parseContractCode(source) as unknown as AST;
+  },
+  buildCallGraph(ast: any): Edge[] {
+    return ((ast as any).edges || []).map((e: any) => ({ from: e.from, to: e.to, label: e.label }));
+  }
+};
+
+const tactAdapter: LanguageAdapter = {
+  fileExtensions: ['.tact'],
+  parse(source: string): AST {
+    return parseTactContract(source) as unknown as AST;
+  },
+  buildCallGraph(ast: any): Edge[] {
+    return ((ast as any).edges || []).map((e: any) => ({ from: e.from, to: e.to, label: e.label }));
+  }
+};
+
+const tolkAdapter: LanguageAdapter = {
+  fileExtensions: ['.tolk'],
+  parse(source: string): AST {
+    return parseTolkContract(source) as unknown as AST;
+  },
+  buildCallGraph(ast: any): Edge[] {
+    return ((ast as any).edges || []).map((e: any) => ({ from: e.from, to: e.to, label: e.label }));
+  }
+};
+
+export { funcAdapter, tactAdapter, tolkAdapter };
+export default [funcAdapter, tactAdapter, tolkAdapter];

--- a/src/languages/func/tactParser.ts
+++ b/src/languages/func/tactParser.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as moo from 'moo';
-import { ContractGraph, ContractNode } from '../types/graph';
-import { GraphNodeKind } from '../types/graphNodeKind';
+import { ContractGraph, ContractNode } from '../../types/graph';
+import { GraphNodeKind } from '../../types/graphNodeKind';
 
 const lexer = moo.compile({
     ws: /[ \t\r]+/,

--- a/src/languages/func/tolkParser.ts
+++ b/src/languages/func/tolkParser.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ContractGraph, ContractNode, GraphEdge } from '../types/graph';
-import { GraphNodeKind } from '../types/graphNodeKind';
+import { ContractGraph, ContractNode, GraphEdge } from '../../types/graph';
+import { GraphNodeKind } from '../../types/graphNodeKind';
 
 // List of built-in functions to exclude
 const BUILT_IN_FUNCTIONS = new Set([

--- a/src/languages/move/index.ts
+++ b/src/languages/move/index.ts
@@ -1,0 +1,29 @@
+import { parse } from '../../move-analyzer/parser';
+import { AST, Edge, LanguageAdapter } from '../../core/types';
+
+export const movelangAdapter: LanguageAdapter = {
+  fileExtensions: ['.move'],
+  parse(source: string): AST {
+    return parse(source);        // full AST
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    const edges: Edge[] = [];
+    const funcs = new Map<string, any>();
+    const a = ast as any;
+
+    // 1️⃣ collect all function declarations
+    a.functions.forEach((fn: any) => funcs.set(fn.name, fn));
+
+    // 2️⃣ walk bodies and record call expressions
+    a.functions.forEach((fn: any) => {
+      fn.body.replace(/(\w+)\s*\(/g, (m: string, name: string) => {
+        if (funcs.has(name)) {
+          edges.push({ from: fn.name, to: name });
+        }
+        return m;
+      });
+    });
+    return edges;
+  }
+};
+export default movelangAdapter;

--- a/src/languages/move/moveParser.ts
+++ b/src/languages/move/moveParser.ts
@@ -1,0 +1,30 @@
+import { parse } from '../../move-analyzer/parser';
+import { ContractGraph, ContractNode } from '../../types/graph';
+import { GraphNodeKind } from '../../types/graphNodeKind';
+
+export async function parseMoveContract(code: string): Promise<ContractGraph> {
+  const ast = parse(code) as any;
+  const graph: ContractGraph = { nodes: [], edges: [] };
+
+  ast.functions.forEach((fn: any) => {
+    const node: ContractNode = {
+      id: fn.name,
+      label: `${fn.name}()`,
+      type: GraphNodeKind.Function,
+      contractName: 'Contract',
+      parameters: [],
+      functionType: 'regular'
+    };
+    graph.nodes.push(node);
+  });
+
+  ast.functions.forEach((fn: any) => {
+    fn.body.replace(/(\w+)\s*\(/g, (m: string, name: string) => {
+      if (ast.functions.find((f: any) => f.name === name)) {
+        graph.edges.push({ from: fn.name, to: name, label: '' });
+      }
+      return m;
+    });
+  });
+  return graph;
+}

--- a/src/lsp-clients/moveClient.ts
+++ b/src/lsp-clients/moveClient.ts
@@ -1,0 +1,19 @@
+import * as child_process from 'child_process';
+import * as vscode from 'vscode';
+import { LanguageClient, StreamInfo } from 'vscode-languageclient/node';
+
+export function startMoveClient(context: vscode.ExtensionContext): vscode.Disposable {
+  const proc = child_process.spawn('move-analyzer', ['--lsp'], {
+    stdio: 'pipe'
+  });
+  const serverOptions = () => Promise.resolve<StreamInfo>({
+    reader: proc.stdout!,
+    writer: proc.stdin!
+  });
+  const client = new LanguageClient('move', 'Move Analyzer', serverOptions, {
+    documentSelector: [{ scheme: 'file', language: 'move' }]
+  });
+  client.start();
+  context.subscriptions.push(client);
+  return client;
+}

--- a/src/move-analyzer/parser.ts
+++ b/src/move-analyzer/parser.ts
@@ -1,0 +1,11 @@
+export interface MoveFunction { name: string; body: string; }
+export interface MoveAST { functions: MoveFunction[]; }
+export function parse(source: string): MoveAST {
+  const functions: MoveFunction[] = [];
+  const fnRegex = /fun\s+(\w+)\s*\([^)]*\)\s*{([\s\S]*?)}/g;
+  let match: RegExpExecArray | null;
+  while ((match = fnRegex.exec(source)) !== null) {
+    functions.push({ name: match[1], body: match[2] });
+  }
+  return { functions };
+}

--- a/test/exportHandler.test.ts
+++ b/test/exportHandler.test.ts
@@ -40,7 +40,7 @@ describe('exportHandler', () => {
     afterEach(() => {
         mock.stopAll();
         delete require.cache[require.resolve('../src/export/exportHandler')];
-        const paths = ['../src/parser/importHandler', '../src/parser/parserUtils'];
+        const paths = ['../src/languages/func/importHandler', '../src/parser/parserUtils'];
         for (const p of paths) {
             if (require.cache[require.resolve(p)]) {
                 delete require.cache[require.resolve(p)];

--- a/test/funcParser.test.ts
+++ b/test/funcParser.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import mock = require('mock-require');
 mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
-import { parseContractCode } from '../src/parser/funcParser';
+import { parseContractCode } from '../src/languages/func/funcParser';
 
 describe('parseContractCode', () => {
     it('parses functions and calls without built-ins', async () => {

--- a/test/importHandler.test.ts
+++ b/test/importHandler.test.ts
@@ -15,12 +15,12 @@ import {
     processTactImports,
     processTolkImports,
     processImports
-} from '../src/parser/importHandler';
+} from '../src/languages/func/importHandler';
 
 describe('ImportHandler', () => {
     afterEach(() => {
         mock.stopAll();
-        delete require.cache[require.resolve('../src/parser/importHandler')];
+        delete require.cache[require.resolve('../src/languages/func/importHandler')];
     });
     it('rejects imports outside workspace', async () => {
         const code = '#include "../../etc/passwd"';
@@ -196,7 +196,7 @@ describe('ImportHandler', () => {
             window: { createOutputChannel: () => ({ appendLine: () => {} }) },
             workspace: { }
         });
-        const { processFuncImports: proc } = require('../src/parser/importHandler');
+        const { processFuncImports: proc } = require('../src/languages/func/importHandler');
         const code = '#include "./file.fc"';
         const res = await proc(code, path.join(testRoot, 'dummy.fc'));
         expect(res.importedFilePaths.length).to.equal(0);
@@ -215,7 +215,7 @@ describe('ImportHandler', () => {
             window: { createOutputChannel: () => ({ appendLine: () => {} }) },
             workspace: { workspaceFolders: [{ uri: { fsPath: tactLoop } }] }
         });
-        const { processTactImports: procT } = require('../src/parser/importHandler');
+        const { processTactImports: procT } = require('../src/languages/func/importHandler');
 
         try {
             await procT(fs.readFileSync(main, 'utf8'), main);
@@ -241,7 +241,7 @@ describe('ImportHandler', () => {
             window: { createOutputChannel: () => ({ appendLine: () => {} }) },
             workspace: {}
         });
-        const { processTactImports: proc } = require('../src/parser/importHandler');
+        const { processTactImports: proc } = require('../src/languages/func/importHandler');
         const res = await proc('import "./lib.tact";', path.join(testRoot, 'dummy.tact'));
         expect(res.importedFilePaths.length).to.equal(0);
     });
@@ -251,7 +251,7 @@ describe('ImportHandler', () => {
             window: { createOutputChannel: () => ({ appendLine: () => {} }) },
             workspace: {}
         });
-        const { processTolkImports: proc } = require('../src/parser/importHandler');
+        const { processTolkImports: proc } = require('../src/languages/func/importHandler');
         const res = await proc('import "./lib.tolk";', path.join(testRoot, 'dummy.tolk'));
         expect(res.importedFilePaths.length).to.equal(0);
     });
@@ -269,7 +269,7 @@ describe('ImportHandler', () => {
             window: { createOutputChannel: () => ({ appendLine: () => {} }) },
             workspace: { workspaceFolders: [{ uri: { fsPath: tolkLoop } }] }
         });
-        const { processTolkImports: proc } = require('../src/parser/importHandler');
+        const { processTolkImports: proc } = require('../src/languages/func/importHandler');
         try {
             await proc(fs.readFileSync(main, 'utf8'), main);
             expect.fail('should throw due to symlink loop');

--- a/test/importHandlerMissingFile.test.ts
+++ b/test/importHandlerMissingFile.test.ts
@@ -8,7 +8,7 @@ mock('vscode', {
   workspace: { workspaceFolders: [{ uri: { fsPath: tmpDir } }] }
 });
 
-import { processFuncImports } from '../src/parser/importHandler';
+import { processFuncImports } from '../src/languages/func/importHandler';
 
 describe('processFuncImports missing file', () => {
   it('returns no imports when file missing', async () => {

--- a/test/moveParser.test.ts
+++ b/test/moveParser.test.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseMoveContract } from '../src/languages/move/moveParser';
+
+const sample = `module M {
+    fun init() {
+        transfer();
+    }
+
+    fun transfer() {
+        credit();
+    }
+
+    fun credit() {}
+}`;
+
+describe('parseMoveContract', () => {
+    it('parses functions and edges', async () => {
+        const graph = await parseMoveContract(sample);
+        const ids = graph.nodes.map(n => n.id);
+        expect(ids).to.have.members(['init', 'transfer', 'credit']);
+        expect(graph.edges).to.deep.include.members([
+            { from: 'init', to: 'transfer', label: '' },
+            { from: 'transfer', to: 'credit', label: '' }
+        ]);
+    });
+});

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -127,7 +127,7 @@ describe('Parser', () => {
         fs.writeFileSync(main, '#include "lib.fc"\nint main() { lib(); }');
         const code = fs.readFileSync(main, 'utf8');
         mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) }, workspace: { workspaceFolders: [{ uri: { fsPath: tmp } }] } });
-        delete require.cache[require.resolve('../src/parser/importHandler')];
+        delete require.cache[require.resolve('../src/languages/func/importHandler')];
         delete require.cache[require.resolve('../src/parser/parserUtils')];
         const { parseContractWithImports: parseWithImports } = require('../src/parser/parserUtils');
         const graph = await parseWithImports(code, main, 'func');

--- a/test/parserUtilsInvalid.test.ts
+++ b/test/parserUtilsInvalid.test.ts
@@ -5,14 +5,14 @@ mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} })
 
 describe('parserUtils invalid inputs', () => {
   afterEach(() => {
-    mock.stop('../src/parser/funcParser');
+    mock.stop('../src/languages/func/funcParser');
     delete require.cache[require.resolve('../src/parser/parserUtils')];
   });
 
   it('falls back to FunC parser for unknown language', async () => {
     delete require.cache[require.resolve('../src/parser/parserUtils')];
     let called = false;
-    mock('../src/parser/funcParser', { parseContractCode: async () => { called = true; return { nodes: [], edges: [] }; } });
+    mock('../src/languages/func/funcParser', { parseContractCode: async () => { called = true; return { nodes: [], edges: [] }; } });
     const parserUtils = require('../src/parser/parserUtils');
     const res = await parserUtils.parseContractByLanguage('code', 'weird' as any);
     expect(called).to.be.true;

--- a/test/parserUtilsWithImports.test.ts
+++ b/test/parserUtilsWithImports.test.ts
@@ -9,13 +9,13 @@ const processImportsStub = async (...args: any[]) => {
   calledWith = args;
   return { importedCode: 'int lib() { return 1; }', importedFilePaths: [], cycles: [] };
 };
-mock('../src/parser/importHandler.ts', { processImports: processImportsStub });
+mock('../src/languages/func/importHandler', { processImports: processImportsStub });
 
 const parserUtils = require('../src/parser/parserUtils');
 
 describe('parserUtils.parseContractWithImports', () => {
   after(() => {
-    mock.stop('../src/parser/importHandler.ts');
+    mock.stop('../src/languages/func/importHandler');
   });
 
   it('combines imported code before parsing', async () => {

--- a/test/tactParser.test.ts
+++ b/test/tactParser.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import mock = require('mock-require');
 mock('vscode', { window: { activeTextEditor: undefined, createOutputChannel: () => ({ appendLine: () => {} }) } });
-import { parseTactContract } from '../src/parser/tactParser';
+import { parseTactContract } from '../src/languages/func/tactParser';
 
 describe('parseTactContract', () => {
     it('parses init, receive, fun and get fun', async () => {

--- a/test/tolkParserFunctions.test.ts
+++ b/test/tolkParserFunctions.test.ts
@@ -10,7 +10,8 @@ import {
     determineFunctionType,
     analyzeFunctionCalls,
     TolkFunctionInfo
-} from '../src/parser/tolkParser';
+} from '../src/languages/func/tolkParser';
+
 
 describe('Tolk parser helper functions', () => {
     const code = fs.readFileSync(path.join(__dirname, 'tolk_sample.tolk'), 'utf-8');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,9 @@
             "es2018",
             "dom"
         ],
+        "paths": {
+            "@move-analyzer/parser": ["./src/move-analyzer/parser"]
+        }
     },
     "include": [
         "src",


### PR DESCRIPTION
## Summary
- refactor to use language adapters and new core layer
- move TON parsers under languages module
- add Move adapter and parser stub
- add Move language client
- extend activation events and package metadata
- update README with Move instructions

## Testing
- `npm run compile`
- `npm test` *(fails: cannot meet coverage thresholds)*

------
https://chatgpt.com/codex/tasks/task_e_684304c0de0c8328bd4df5eb85e0b9c2