### PR TITLE
Add parser caching

### DIFF
--- a/src/commands/visualize.ts
+++ b/src/commands/visualize.ts
@@ -40,7 +40,7 @@ export async function visualize(context: vscode.ExtensionContext, fileUri?: vsco
     try {
         const language = detectLanguage(document.fileName);
         logger.debug(`Detected language ${language}`);
-        originalGraph = await parseContractByLanguage(code, language);
+        originalGraph = await parseContractByLanguage(code, language, document.uri);
         logger.debug('Parsed contract to graph');
 
         if (panel) {

--- a/test/funcParser.test.ts
+++ b/test/funcParser.test.ts
@@ -37,4 +37,17 @@ describe('parseContractCode', () => {
         expect(foo?.parameters).to.deep.equal(['int a']);
         expect(main?.parameters).to.deep.equal(['int b']);
     });
+
+    it('uses cache for repeated parses', async () => {
+        let called = 0;
+        mock.stop('../src/languages/func/funcParser');
+        mock('../src/languages/func/funcParser', { parseContractCode: async () => { called++; return { nodes: [], edges: [] }; } });
+        delete require.cache[require.resolve('../src/parser/parserUtils')];
+        const { parseContractByLanguage } = require('../src/parser/parserUtils');
+        const uri = { toString() { return 'file:///cache.fc'; } } as any;
+        await parseContractByLanguage('code', 'func', uri);
+        await parseContractByLanguage('code', 'func', uri);
+        expect(called).to.equal(1);
+        mock.stop('../src/languages/func/funcParser');
+    });
 });

--- a/test/moveParser.test.ts
+++ b/test/moveParser.test.ts
@@ -25,4 +25,17 @@ describe('parseMoveContract', () => {
             { from: 'transfer', to: 'credit', label: '' }
         ]);
     });
+
+    it('uses cache for repeated parses', async () => {
+        let called = 0;
+        mock.stop('../src/languages/move/moveParser');
+        mock('../src/languages/move/moveParser', { parseMoveContract: async () => { called++; return { nodes: [], edges: [] }; } });
+        delete require.cache[require.resolve('../src/parser/parserUtils')];
+        const { parseContractByLanguage } = require('../src/parser/parserUtils');
+        const uri = { toString() { return 'file:///cache.move'; } } as any;
+        await parseContractByLanguage('code', 'move', uri);
+        await parseContractByLanguage('code', 'move', uri);
+        expect(called).to.equal(1);
+        mock.stop('../src/languages/move/moveParser');
+    });
 });


### PR DESCRIPTION
## Summary
- cache parsed ASTs in GraphProvider to avoid reparsing
- cache parseContractByLanguage results by file URI and language
- reset caches on text change
- pass document URI to parseContractByLanguage
- test caching for FunC and Move parsers

## Testing
- `npm run compile`
- `npm test` *(fails: 12 failing)*

------
https://chatgpt.com/codex/tasks/task_e_68430cbfcbdc83288a98ebe99a2ea3c3