### PR TITLE
Add Move tree-sitter parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dompurify": "^3.2.6",
         "mermaid": "^11.6.0",
         "moo": "^0.5.2",
+        "tree-sitter-move": "github:tzakian/tree-sitter-move",
         "vscode-languageclient": "^9.0.1",
         "web-tree-sitter": "^0.25.6",
         "winston": "^3.17.0"
@@ -9640,6 +9641,17 @@
         }
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -12548,6 +12560,52 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tree-sitter": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
+      "integrity": "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      }
+    },
+    "node_modules/tree-sitter-move": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/tzakian/tree-sitter-move.git#f5b37f63569f69dfbe7a9950527786d2f6b1d35c",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "node-addon-api": "^7.1.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "peerDependencies": {
+        "tree-sitter": "^0.21.0"
+      },
+      "peerDependenciesMeta": {
+        "tree_sitter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tree-sitter-move/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/tree-sitter/node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/trim-newlines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -190,9 +190,10 @@
     "dompurify": "^3.2.6",
     "mermaid": "^11.6.0",
     "moo": "^0.5.2",
+    "tree-sitter-move": "github:tzakian/tree-sitter-move",
+    "vscode-languageclient": "^9.0.1",
     "web-tree-sitter": "^0.25.6",
-    "winston": "^3.17.0",
-    "vscode-languageclient": "^9.0.1"
+    "winston": "^3.17.0"
   },
   "files": [
     "out/**/*",

--- a/src/__tests__/move/ChainId.move
+++ b/src/__tests__/move/ChainId.move
@@ -1,0 +1,24 @@
+module DiemFramework::ChainId {
+    use DiemFramework::CoreAddresses;
+    use DiemFramework::DiemTimestamp;
+    use Std::Errors;
+    use Std::Signer;
+
+    struct ChainId has key {
+        id: u8
+    }
+
+    const ECHAIN_ID: u64 = 0;
+
+    public fun initialize(dr_account: &signer, id: u8) {
+        DiemTimestamp::assert_genesis();
+        CoreAddresses::assert_diem_root(dr_account);
+        assert(!exists<ChainId>(Signer::address_of(dr_account)), Errors::already_published(ECHAIN_ID));
+        move_to(dr_account, ChainId { id })
+    }
+
+    public fun get(): u8 acquires ChainId {
+        DiemTimestamp::assert_operating();
+        borrow_global<ChainId>(@DiemRoot).id
+    }
+}

--- a/src/__tests__/move/aptos_token.move
+++ b/src/__tests__/move/aptos_token.move
@@ -1,0 +1,26 @@
+module aptos_token::token {
+    use std::error;
+    use std::option::{Self, Option};
+    use std::signer;
+    use std::string::{Self, String};
+    use std::vector;
+
+    public entry fun create_collection_script(
+        account: &signer,
+        name: String,
+        description: String,
+        uri: String,
+    ) {
+        // simplified
+        create_collection(account, name, description, uri);
+    }
+
+    public fun create_collection(
+        account: &signer,
+        name: String,
+        description: String,
+        uri: String,
+    ) {
+        vector::length(&vector[]);
+    }
+}

--- a/src/__tests__/move/sui_example.move
+++ b/src/__tests__/move/sui_example.move
@@ -1,0 +1,32 @@
+module my_first_package::example {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    public struct Sword has key, store {
+        id: UID,
+        magic: u64,
+        strength: u64,
+    }
+
+    public struct Forge has key {
+        id: UID,
+        swords_created: u64,
+    }
+
+    fun init(ctx: &mut TxContext) {
+        let admin = Forge {
+            id: object::new(ctx),
+            swords_created: 0,
+        };
+        transfer::transfer(admin, ctx.sender());
+    }
+
+    public fun sword_create(magic: u64, strength: u64, ctx: &mut TxContext): Sword {
+        Sword {
+            id: object::new(ctx),
+            magic,
+            strength,
+        }
+    }
+}

--- a/src/languages/move/moveParser.ts
+++ b/src/languages/move/moveParser.ts
@@ -1,30 +1,63 @@
-import { parse } from '../../move-analyzer/parser';
+import { parseMove } from '@parser/move';
 import { ContractGraph, ContractNode } from '../../types/graph';
 import { GraphNodeKind } from '../../types/graphNodeKind';
 
+function walk(node: any, type: string): any[] {
+  const res: any[] = [];
+  const stack = [node];
+  while (stack.length) {
+    const n = stack.pop();
+    if (!n) continue;
+    if (n.type === type) res.push(n);
+    stack.push(...n.namedChildren);
+  }
+  return res;
+}
+
 export async function parseMoveContract(code: string): Promise<ContractGraph> {
-  const ast = parse(code) as any;
+  const { ast } = parseMove(code);
   const graph: ContractGraph = { nodes: [], edges: [] };
+  const funcMap = new Map<string, ContractNode>();
 
-  ast.functions.forEach((fn: any) => {
-    const node: ContractNode = {
-      id: fn.name,
-      label: `${fn.name}()`,
-      type: GraphNodeKind.Function,
-      contractName: 'Contract',
-      parameters: [],
-      functionType: 'regular'
-    };
-    graph.nodes.push(node);
-  });
+  for (const m of ast.modules) {
+    for (const f of m.functions) {
+      const id = `${m.name}::${f.name}`;
+      const node: ContractNode = {
+        id,
+        label: `${f.name}()`,
+        type: GraphNodeKind.Function,
+        contractName: m.name,
+        parameters: [],
+        functionType: f.isPublic ? 'public' : 'regular'
+      };
+      graph.nodes.push(node);
+      funcMap.set(id, node);
+    }
+  }
 
-  ast.functions.forEach((fn: any) => {
-    fn.body.replace(/(\w+)\s*\(/g, (m: string, name: string) => {
-      if (ast.functions.find((f: any) => f.name === name)) {
-        graph.edges.push({ from: fn.name, to: name, label: '' });
+  for (const m of ast.modules) {
+    const useMap = new Map<string,string>();
+    m.uses.forEach(u => useMap.set(u.alias, u.path));
+    for (const f of m.functions) {
+      if (!f.body) continue;
+      const from = `${m.name}::${f.name}`;
+      const calls = walk(f.body, 'call_expression');
+      for (const call of calls) {
+        const access = call.namedChildren[0]?.namedChildren?.find((c:any)=>c.fieldName==='access') || call.childForFieldName('access');
+        let path = access ? access.text : '';
+        if (!path) continue;
+        if (!path.includes('::')) {
+          path = useMap.get(path) || `${m.name}::${path}`;
+        }
+        const to = path;
+        if (!funcMap.has(to)) {
+          graph.nodes.push({ id: to, label: path, type: GraphNodeKind.Function, contractName: path.split('::')[path.split('::').length-2] || path, });
+          funcMap.set(to, graph.nodes[graph.nodes.length-1]);
+        }
+        graph.edges.push({ from, to, label: '' });
       }
-      return m;
-    });
-  });
+    }
+  }
+
   return graph;
 }

--- a/src/parser/moveParser.ts
+++ b/src/parser/moveParser.ts
@@ -1,0 +1,92 @@
+import Parser from 'tree-sitter';
+import Move from 'tree-sitter-move';
+
+export interface MoveImport {
+  alias: string;
+  path: string;
+}
+
+export interface MoveFunction {
+  name: string;
+  isPublic: boolean;
+  body?: Parser.SyntaxNode;
+}
+
+export interface MoveModule {
+  name: string;
+  address?: string;
+  uses: MoveImport[];
+  functions: MoveFunction[];
+}
+
+export interface MoveAST {
+  modules: MoveModule[];
+}
+
+let parser: Parser | null = null;
+function getParser(): Parser {
+  if (!parser) {
+    parser = new Parser();
+    parser.setLanguage(Move as any);
+  }
+  return parser;
+}
+
+function findNodes(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode[] {
+  const result: Parser.SyntaxNode[] = [];
+  const stack: Parser.SyntaxNode[] = [node];
+  while (stack.length) {
+    const n = stack.pop()!;
+    if (n.type === type) result.push(n);
+    for (const child of n.namedChildren) stack.push(child);
+  }
+  return result;
+}
+
+export function parseMove(code: string): { ast: MoveAST; tree: Parser.Tree } {
+  const p = getParser();
+  const tree = p.parse(code);
+  const modules: MoveModule[] = [];
+  for (const moduleNode of findNodes(tree.rootNode, 'module_definition')) {
+    const idNode = moduleNode.childForFieldName('module_identity');
+    let moduleName = '';
+    let address: string | undefined;
+    if (idNode) {
+      const addr = idNode.childForFieldName('address');
+      const mod = idNode.childForFieldName('module');
+      if (addr) address = addr.text;
+      if (mod) moduleName = mod.text;
+    }
+    const body = moduleNode.childForFieldName('module_body');
+    const uses: MoveImport[] = [];
+    const functions: MoveFunction[] = [];
+    if (body) {
+      for (const child of body.namedChildren) {
+        if (child.type === 'use_declaration') {
+          let text = child.text.replace(/^public\s+/, '');
+          text = text.replace(/^use\s+/, '').replace(/;$/, '').trim();
+          const parts = text.split(/\s+as\s+/);
+          const path = parts[0].trim();
+          const alias = parts[1] ? parts[1].trim() : path.split('::').pop()!;
+          uses.push({ alias, path });
+        } else if (child.type === 'function_definition') {
+          const nameNode = child.childForFieldName('name');
+          if (!nameNode) continue;
+          const sig = child.child(0);
+          let isPublic = false;
+          if (sig) {
+            for (const sc of sig.namedChildren) {
+              if (sc.type === 'modifier' && sc.text.startsWith('public')) {
+                isPublic = true;
+              }
+            }
+          }
+          const bodyNode = child.childForFieldName('body');
+          functions.push({ name: nameNode.text, isPublic, body: bodyNode || undefined });
+        }
+      }
+    }
+    modules.push({ name: moduleName, address, uses, functions });
+  }
+  return { ast: { modules }, tree };
+}

--- a/test/moveRealContracts.test.ts
+++ b/test/moveRealContracts.test.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseMoveContract } from '../src/languages/move/moveParser';
+
+function load(name: string) {
+  return fs.readFileSync(`src/__tests__/move/${name}.move`, 'utf8');
+}
+
+describe('parseMoveContract real contracts', () => {
+  it('Diem ChainId', async () => {
+    const graph = await parseMoveContract(load('ChainId'));
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.include('ChainId::initialize');
+    expect(ids).to.include('ChainId::get');
+    expect(graph.edges).to.deep.include.members([
+      { from: 'ChainId::initialize', to: 'DiemTimestamp::assert_genesis', label: '' },
+      { from: 'ChainId::initialize', to: 'CoreAddresses::assert_diem_root', label: '' }
+    ]);
+  });
+
+  it('Sui example', async () => {
+    const graph = await parseMoveContract(load('sui_example'));
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.include('example::sword_create');
+    expect(graph.edges).to.deep.include.members([
+      { from: 'example::init', to: 'object::new', label: '' },
+      { from: 'example::init', to: 'transfer::transfer', label: '' }
+    ]);
+  });
+
+  it('Aptos token', async () => {
+    const graph = await parseMoveContract(load('aptos_token'));
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.include('token::create_collection_script');
+    expect(graph.edges).to.deep.include({ from: 'token::create_collection_script', to: 'token::create_collection', label: '' });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
             "dom"
         ],
         "paths": {
-            "@move-analyzer/parser": ["./src/move-analyzer/parser"]
+            "@move-analyzer/parser": ["./src/move-analyzer/parser"],
+            "@parser/move": ["./src/parser/moveParser"]
         }
     },
     "include": [


### PR DESCRIPTION
## Summary
- add `tree-sitter-move` dependency
- implement Move parser using tree-sitter
- update Move call graph builder
- support import edges and cross-module calls
- add real Move contract samples and tests
- update TypeScript paths

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684310033b7c83288967f651fb8ab2ae