### PR TITLE
Enhance webview security with nonce and event checks

### DIFF
--- a/src/visualization/htmlTemplate.ts
+++ b/src/visualization/htmlTemplate.ts
@@ -1,6 +1,11 @@
 import { VISUALIZATION_TEMPLATE } from './visualizationTemplate';
 import * as vscode from 'vscode';
 
+function getNonce(): string {
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    return Array.from({ length: 32 }, () => possible.charAt(Math.floor(Math.random() * possible.length))).join('');
+}
+
 export function generateVisualizationHtml(
     mermaidDiagram: string,
     mermaidScriptUri: string,
@@ -9,9 +14,11 @@ export function generateVisualizationHtml(
     webview: vscode.Webview,
     theme = 'default'
 ): string {
+    const nonce = getNonce();
     const filtersJson = JSON.stringify(functionTypeFilters);
-    const cspMetaTag = `<meta http-equiv="Content-Security-Policy" content="default-src 'self' vscode-resource:; script-src 'nonce-${webview.cspSource}'; style-src 'self' vscode-resource:; img-src 'self' data: vscode-resource:">`;
+    const cspMetaTag = `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'nonce-${nonce}' vscode-resource:; img-src vscode-resource: data:">`;
     return VISUALIZATION_TEMPLATE.replace('<head>', `<head>${cspMetaTag}`)
+        .replace(/{{NONCE}}/g, nonce)
         .replace('{{MERMAID_DIAGRAM}}', mermaidDiagram)
         .replace('{{MERMAID_SCRIPT_URI}}', mermaidScriptUri)
         .replace('{{FILTERS_JSON}}', filtersJson)

--- a/src/visualization/visualizationTemplate.ts
+++ b/src/visualization/visualizationTemplate.ts
@@ -4,7 +4,7 @@ export const VISUALIZATION_TEMPLATE = `<!DOCTYPE html>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>TON Graph</title>
-        <style>
+        <style nonce="{{NONCE}}">
             body {
                 margin: 0;
                 padding: 0;
@@ -261,9 +261,9 @@ export const VISUALIZATION_TEMPLATE = `<!DOCTYPE html>
             <canvas id="imageCanvas" style="display:none;"></canvas>
             <a id="downloadLink" style="display: none;">Download</a>
         </div>
-        <script>window.filterSet = {{FILTERS_JSON}};</script>
-        <script>window.mermaidTheme = "{{MERMAID_THEME}}";</script>
-        <script src="{{MERMAID_SCRIPT_URI}}"></script>
-        <script src="{{WEBVIEW_SCRIPT_URI}}"></script>
+        <script nonce="{{NONCE}}">window.filterSet = {{FILTERS_JSON}};</script>
+        <script nonce="{{NONCE}}">window.mermaidTheme = "{{MERMAID_THEME}}";</script>
+        <script nonce="{{NONCE}}" src="{{MERMAID_SCRIPT_URI}}"></script>
+        <script nonce="{{NONCE}}" src="{{WEBVIEW_SCRIPT_URI}}"></script>
     </body>
     </html>`;

--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -76,17 +76,21 @@ document.getElementById('loadingOverlay').classList.add('hidden');
 });
 var vscode = acquireVsCodeApi();
 window.addEventListener('message', function(event) {
-const message = event.data;
-switch (message.command) {
-case 'updateDiagram':
-const mermaidDiagram = document.getElementById('mermaid-diagram');
-mermaidDiagram.textContent = message.diagram;
-mermaidDiagram.setAttribute('data-original-code', message.diagram);
-const fontSize = 14;
-const nodeSpacing = 15;
-const rankSpacing = 15;
-mermaid.initialize({
-startOnLoad: false,
+  const message = event.data;
+  if (!message || typeof message !== 'object' || typeof message.command !== 'string') {
+    return;
+  }
+  switch (message.command) {
+  case 'updateDiagram':
+    if (typeof message.diagram !== 'string') return;
+    const mermaidDiagram = document.getElementById('mermaid-diagram');
+    mermaidDiagram.textContent = message.diagram;
+    mermaidDiagram.setAttribute('data-original-code', message.diagram);
+    const fontSize = 14;
+    const nodeSpacing = 15;
+    const rankSpacing = 15;
+    mermaid.initialize({
+      startOnLoad: false,
 securityLevel: 'strict',
 theme: mermaidTheme || 'default',
 fontSize: fontSize,
@@ -108,14 +112,15 @@ logMessage('Diagram updated with filters', 'success');
 document.getElementById('errorContainer').textContent = 'Error updating diagram: ' + error;
 document.getElementById('errorContainer').style.display = 'block';
 logMessage('Error updating diagram: ' + error, 'error');
-});
-break;
-case 'filterError':
-document.getElementById('errorContainer').textContent = message.error;
-document.getElementById('errorContainer').style.display = 'block';
-logMessage('Filter error: ' + message.error, 'error');
-break;
-}
+    });
+    break;
+  case 'filterError':
+    if (typeof message.error !== 'string') return;
+    document.getElementById('errorContainer').textContent = message.error;
+    document.getElementById('errorContainer').style.display = 'block';
+    logMessage('Filter error: ' + message.error, 'error');
+    break;
+  }
 });
 function logMessage(message, type) {
 const logContainer = document.getElementById('logContainer');

--- a/test/htmlTemplate.test.ts
+++ b/test/htmlTemplate.test.ts
@@ -13,7 +13,7 @@ describe("generateVisualizationHtml", () => {
       "dark"
     );
     expect(html).to.include("Content-Security-Policy");
-    expect(html).to.include(`nonce-${webview.cspSource}`);
+    expect(html).to.match(/nonce="[A-Za-z0-9]{32}"/);
     expect(html).to.include("graph TB;");
     expect(html).to.include("mermaid.js");
     expect(html).to.include("script.js");

--- a/test/webviewSanitize.test.ts
+++ b/test/webviewSanitize.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { JSDOM } from 'jsdom';
 import createDOMPurify = require('dompurify');
+import mock = require('mock-require');
 
 describe('webview sanitize', () => {
   it('removes script elements from SVG', () => {
@@ -10,5 +11,46 @@ describe('webview sanitize', () => {
     const clean = DOMPurify.sanitize(dirty, {USE_PROFILES: {svg: true, svgFilters: true}});
     expect(clean).to.not.include('<script>');
     expect(clean).to.include('<rect');
+  });
+
+  it('ignores malicious message events', async () => {
+    const html = `<!DOCTYPE html>
+      <div id="mermaid-diagram"></div>`;
+    const dom = new JSDOM(html, { url: 'http://localhost' });
+    (global as any).window = dom.window as any;
+    (global as any).document = dom.window.document;
+    (global as any).filterSet = [];
+    (global as any).acquireVsCodeApi = () => ({ postMessage: () => {} });
+    (global as any).mermaid = {
+      initialize: () => {},
+      render: () => Promise.resolve({ svg: '<svg></svg>' })
+    };
+
+    const DOMPurify = createDOMPurify(dom.window as any);
+    const sanitizeMock = (s: string) => DOMPurify.sanitize(s, { USE_PROFILES: { svg: true, svgFilters: true } });
+    mock('dompurify', { default: { sanitize: sanitizeMock } });
+    delete require.cache[require.resolve('../src/webview/index.ts')];
+    require('../src/webview/index.ts');
+
+    await new Promise(res => setTimeout(res, 0));
+
+    const container = dom.window.document.getElementById('mermaid-diagram')!;
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { command: 'updateDiagram', diagram: '<svg><script>alert(1)</script></svg>' }
+    }));
+    expect(container.innerHTML).to.not.include('<script>');
+
+    const initial = container.innerHTML;
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', { data: '<script>alert(1)</script>' }));
+    expect(container.innerHTML).to.equal(initial);
+
+    mock.stopAll();
+    delete require.cache[require.resolve('../src/webview/index.ts')];
+    dom.window.close();
+    delete (global as any).window;
+    delete (global as any).document;
+    delete (global as any).filterSet;
+    delete (global as any).acquireVsCodeApi;
+    delete (global as any).mermaid;
   });
 });


### PR DESCRIPTION
## Summary
- generate a random nonce for CSP and script/style tags
- include nonce in visualization template scripts
- validate incoming messages in the webview client
- adjust tests for nonce logic and add malicious message scenario

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431ee0c6cc8328a7eb4db1c199b9f3