### PR TITLE
Add Move examples and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+- Added Move language support via `move-analyzer`.
+- Updated documentation and package description.
+- Added example Move contracts under `examples/move/`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - FunC (*.fc, *.func)
   - Tact (*.tact)
   - Tolk (*.tolk)
-  - Move (*.move)
+  - Move (*.move) - requires `move-analyzer`
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -44,11 +44,12 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 3. Search for "TON Graph"
 4. Click Install
 5. Run "TON Graph: Set API Key" from the command palette and enter your Toncenter API key
-6. Install the `move-analyzer` binary and ensure it is available in your PATH
+6. Install the `move-analyzer` binary and ensure it is available in your PATH (required for Move support)
 
 ## Usage
 
 1. Open a contract file (*.fc, *.func, *.tact, *.tolk, or *.move)
+Note: Move contracts are parsed via `move-analyzer`.
 2. You can visualize a contract in multiple ways:
    - Press F1 or Ctrl+Shift+P to open the command palette and type "TON Graph: Visualize Contract"
    - Right-click on contract code in the editor → TON Graph: Visualize Contract
@@ -59,7 +60,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 You can also visualize an entire contract including all imports:
 
-1. Open a main contract file (*.fc, *.func, *.tact, or *.tolk)
+1. Open a main contract file (*.fc, *.func, *.tact, *.tolk, or *.move)
 2. Visualize the project in one of these ways:
    - Press F1 or Ctrl+Shift+P and type "TON Graph: Visualize Contract with Imports"
    - Right-click on contract code in the editor → TON Graph: Visualize Contract with Imports

--- a/examples/move/ChainId.move
+++ b/examples/move/ChainId.move
@@ -1,0 +1,25 @@
+// Diem framework module to initialize Chain ID
+module DiemFramework::ChainId {
+    use DiemFramework::CoreAddresses;
+    use DiemFramework::DiemTimestamp;
+    use Std::Errors;
+    use Std::Signer;
+
+    struct ChainId has key {
+        id: u8
+    }
+
+    const ECHAIN_ID: u64 = 0;
+
+    public fun initialize(dr_account: &signer, id: u8) {
+        DiemTimestamp::assert_genesis();
+        CoreAddresses::assert_diem_root(dr_account);
+        assert(!exists<ChainId>(Signer::address_of(dr_account)), Errors::already_published(ECHAIN_ID));
+        move_to(dr_account, ChainId { id })
+    }
+
+    public fun get(): u8 acquires ChainId {
+        DiemTimestamp::assert_operating();
+        borrow_global<ChainId>(@DiemRoot).id
+    }
+}

--- a/examples/move/aptos_token.move
+++ b/examples/move/aptos_token.move
@@ -1,0 +1,27 @@
+// Simplified snippet from the Aptos token module
+module aptos_token::token {
+    use std::error;
+    use std::option::{Self, Option};
+    use std::signer;
+    use std::string::{Self, String};
+    use std::vector;
+
+    public entry fun create_collection_script(
+        account: &signer,
+        name: String,
+        description: String,
+        uri: String,
+    ) {
+        // simplified
+        create_collection(account, name, description, uri);
+    }
+
+    public fun create_collection(
+        account: &signer,
+        name: String,
+        description: String,
+        uri: String,
+    ) {
+        vector::length(&vector[]);
+    }
+}

--- a/examples/move/sui_example.move
+++ b/examples/move/sui_example.move
@@ -1,0 +1,33 @@
+// Sui sample contract creating swords
+module my_first_package::example {
+    use sui::object::{Self, UID};
+    use sui::transfer;
+    use sui::tx_context::{Self, TxContext};
+
+    public struct Sword has key, store {
+        id: UID,
+        magic: u64,
+        strength: u64,
+    }
+
+    public struct Forge has key {
+        id: UID,
+        swords_created: u64,
+    }
+
+    fun init(ctx: &mut TxContext) {
+        let admin = Forge {
+            id: object::new(ctx),
+            swords_created: 0,
+        };
+        transfer::transfer(admin, ctx.sender());
+    }
+
+    public fun sword_create(magic: u64, strength: u64, ctx: &mut TxContext): Sword {
+        Sword {
+            id: object::new(ctx),
+            magic,
+            strength,
+        }
+    }
+}

--- a/marketplace-description.md
+++ b/marketplace-description.md
@@ -1,0 +1,1 @@
+Visualize function call graphs for FunC, Tact, Tolk and Move contracts. Move support requires the move-analyzer tool.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ton-graph",
   "displayName": "TON Graph",
-  "description": "Visualize function calls for TON smart contracts",
+  "description": "Visualize function call graphs for FunC, Tact, Tolk and Move contracts. Move support requires the move-analyzer utility",
   "version": "0.2.6",
   "publisher": "positiveweb3",
   "icon": "pic/logo.png",


### PR DESCRIPTION
## Summary
- document Move support and mention move-analyzer
- add Move example contracts under `examples/move`
- update package description and marketplace blurb
- start a changelog

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843296f3fd88328a8355f854a8afc85