### PR TITLE
Add schema validation and retry limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "tree-sitter-move": "github:tzakian/tree-sitter-move",
         "vscode-languageclient": "^9.0.1",
         "web-tree-sitter": "^0.25.6",
-        "winston": "^3.17.0"
+        "winston": "^3.17.0",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.8.1",
@@ -13883,6 +13884,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.55",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.55.tgz",
+      "integrity": "sha512-219huNnkSLQnLsQ3uaRjXsxMrVm5C9W3OOpEVt2k5tvMKuA8nBSu38e0B//a+he9Iq2dvmk2VyYVlHqiHa4YBA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -193,7 +193,8 @@
     "tree-sitter-move": "github:tzakian/tree-sitter-move",
     "vscode-languageclient": "^9.0.1",
     "web-tree-sitter": "^0.25.6",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "zod": "^3.22.4"
   },
   "files": [
     "out/**/*",


### PR DESCRIPTION
## Summary
- validate toncenter responses with zod before caching
- use capped timeout and fixed retry limit
- update tests with msw for malformed and delayed responses
- add `zod` runtime dependency

## Testing
- `npx nyc mocha -r ts-node/register test/toncenter.test.ts` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433261a8848328b7c10d3cc979bb12