### PR TITLE
Fix API key log filtering

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -30,7 +30,7 @@ const sanitizeFormat = format((info) => {
     }
     if (typeof value === 'string') {
       value = redactPaths(value);
-      const apiKeyPattern = /(api[_-]?key\s*[=:]\s*)([^\s]+)/i;
+      const apiKeyPattern = /(api[_-]?key[^\s]*?[=:])([^\s]*)/i;
       return value.replace(apiKeyPattern, '$1[FILTERED]');
     }
     return value;

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -33,9 +33,15 @@ describe('Logger', () => {
 
   it('filters sensitive information', () => {
     logger.error('failed with api_key=SECRET', { api_key: 'SECRET', path: '/tmp/secret.txt' });
-    const last = outputChannel.messages[outputChannel.messages.length - 1];
-    expect(last).to.not.include('SECRET');
-    expect(last).to.not.include('/tmp/secret.txt');
+    logger.error('bad api-key:SECRET');
+    logger.error('bad apikey=SECRET');
+    logger.error('bad apikey?value=SECRET');
+    const lastFour = outputChannel.messages.slice(-4);
+    for (const msg of lastFour) {
+      expect(msg).to.not.include('SECRET');
+      expect(msg).to.include('[FILTERED]');
+    }
+    expect(lastFour[0]).to.not.include('/tmp/secret.txt');
   });
 
   it('redacts absolute paths with spaces and quotes', () => {


### PR DESCRIPTION
## Summary
- expand the regex in `logger.ts` to catch many API key styles
- cover more API key patterns in unit tests

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843355b5bc88328b6ee802225e5ca0d