### PR TITLE
Sanitize links in webview

### DIFF
--- a/src/webview/index.ts
+++ b/src/webview/index.ts
@@ -80,7 +80,9 @@ const sanitizedSvg = DOMPurify.sanitize(result.svg, {
   ALLOWED_ATTR,
   SAFE_FOR_TEMPLATES: true
 });
-document.getElementById('mermaid-diagram').innerHTML = sanitizedSvg;
+const diagramContainer = document.getElementById('mermaid-diagram');
+diagramContainer.innerHTML = sanitizedSvg;
+secureLinks(diagramContainer);
 setupPanZoom();
 logMessage('Diagram rendered successfully', 'success');
 document.getElementById('loadingOverlay').classList.add('hidden');
@@ -126,6 +128,7 @@ const sanitizedUpdateSvg = DOMPurify.sanitize(result.svg, {
   SAFE_FOR_TEMPLATES: true
 });
 mermaidDiagram.innerHTML = sanitizedUpdateSvg;
+secureLinks(mermaidDiagram);
 setupPanZoom();
 logMessage('Diagram updated with filters', 'success');
 }).catch(function(error) {
@@ -240,4 +243,17 @@ codeDisplay.style.display = 'block';
 mermaidContainer.style.display = 'none';
 document.getElementById('showCodeBtn').textContent = 'Show Diagram';
 }
+}
+
+function secureLinks(container) {
+  const anchors = container.querySelectorAll('a');
+  anchors.forEach(function(anchor) {
+    const href = anchor.getAttribute('href');
+    if (href && /^\s*javascript:/i.test(href)) {
+      anchor.removeAttribute('href');
+    } else if (href) {
+      anchor.setAttribute('target', '_blank');
+      anchor.setAttribute('rel', 'noopener noreferrer');
+    }
+  });
 }

--- a/test/webviewSanitize.test.ts
+++ b/test/webviewSanitize.test.ts
@@ -21,6 +21,71 @@ describe('webview sanitize', () => {
     expect(clean).to.not.include('onload');
   });
 
+  it('neutralizes javascript links', async () => {
+    const html = `<!DOCTYPE html>
+      <div id="mermaid-diagram"></div>`;
+    const dom = new JSDOM(html, { url: 'http://localhost' });
+    (global as any).window = dom.window as any;
+    (global as any).document = dom.window.document;
+    (global as any).filterSet = [];
+    (global as any).acquireVsCodeApi = () => ({ postMessage: () => {} });
+    (global as any).mermaid = {
+      initialize: () => {},
+      render: () => Promise.resolve({ svg: '<svg><a href="javascript:alert(1)">bad</a></svg>' })
+    };
+
+    mock('dompurify', { default: { sanitize: (s: string) => s } });
+    delete require.cache[require.resolve('../src/webview/index.ts')];
+    require('../src/webview/index.ts');
+
+    await new Promise(res => setTimeout(res, 0));
+
+    const link = dom.window.document.querySelector('a')!;
+    expect(link.hasAttribute('href')).to.be.false;
+
+    mock.stopAll();
+    delete require.cache[require.resolve('../src/webview/index.ts')];
+    dom.window.close();
+    delete (global as any).window;
+    delete (global as any).document;
+    delete (global as any).filterSet;
+    delete (global as any).acquireVsCodeApi;
+    delete (global as any).mermaid;
+  });
+
+  it('enforces rel and target on external links', async () => {
+    const html = `<!DOCTYPE html>
+      <div id="mermaid-diagram"></div>`;
+    const dom = new JSDOM(html, { url: 'http://localhost' });
+    (global as any).window = dom.window as any;
+    (global as any).document = dom.window.document;
+    (global as any).filterSet = [];
+    (global as any).acquireVsCodeApi = () => ({ postMessage: () => {} });
+    (global as any).mermaid = {
+      initialize: () => {},
+      render: () => Promise.resolve({ svg: '<svg><a href="http://example.com">ok</a></svg>' })
+    };
+
+    mock('dompurify', { default: { sanitize: (s: string) => s } });
+    delete require.cache[require.resolve('../src/webview/index.ts')];
+    require('../src/webview/index.ts');
+
+    await new Promise(res => setTimeout(res, 0));
+
+    const link = dom.window.document.querySelector('a')!;
+    expect(link.getAttribute('target')).to.equal('_blank');
+    expect(link.getAttribute('rel')).to.equal('noopener noreferrer');
+
+    mock.stopAll();
+    delete require.cache[require.resolve('../src/webview/index.ts')];
+    dom.window.close();
+    delete (global as any).window;
+    delete (global as any).document;
+    delete (global as any).filterSet;
+    delete (global as any).acquireVsCodeApi;
+    delete (global as any).mermaid;
+  });
+
   it('ignores malicious message events', async () => {
     const html = `<!DOCTYPE html>
       <div id="mermaid-diagram"></div>`;


### PR DESCRIPTION
## Summary
- sanitize webview links by removing javascript URLs and enforcing rel+target
- test handling of unsafe links

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843371974a08328ac203105ffa0e318