### PR TITLE
Add SECURITY doc and extend logger redaction tests

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Secret Storage
+
+TON Graph stores the TONcenter API key exclusively using VS Code's `ExtensionContext.secrets` API.
+The implementation in [src/secrets/tokenManager.ts](src/secrets/tokenManager.ts)
+invokes `context.secrets.get`, `context.secrets.store`, and `context.secrets.delete` to
+retrieve, save, and remove the key. VS Code encrypts these secrets on disk, so no
+API keys are written to the extension's configuration files or logs.

--- a/test/logger.test.ts
+++ b/test/logger.test.ts
@@ -44,6 +44,23 @@ describe('Logger', () => {
     expect(lastFour[0]).to.not.include('/tmp/secret.txt');
   });
 
+  it('filters api keys in nested objects and arrays', () => {
+    logger.error('nested object', { cfg: { auth: { apiKey: 'SECRET1' } } });
+    logger.error('array of values', {
+      items: [
+        { 'x-api-key': 'SECRET2' },
+        { deep: { api_key: 'SECRET3' } },
+      ],
+    });
+    const lastTwo = outputChannel.messages.slice(-2);
+    for (const msg of lastTwo) {
+      expect(msg).to.not.include('SECRET1');
+      expect(msg).to.not.include('SECRET2');
+      expect(msg).to.not.include('SECRET3');
+      expect(msg).to.include('[FILTERED]');
+    }
+  });
+
   it('redacts absolute paths with spaces and quotes', () => {
     logger.info('opening "C:\\Secret Folder\\file.txt"');
     logger.info("processing '/tmp/some file '");


### PR DESCRIPTION
## Summary
- document how API keys are stored securely
- add logger test cases for nested API key redaction

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433a124e4c83288919ac4bf3860e48