### PR TITLE
Add governance and emergency procedures

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,23 @@
+# Project Governance
+
+This document defines how decisions are made for the TON Graph project.
+
+## Roles
+
+- **Maintainers** – individuals with write access to the repository and publishing rights on the VS Code Marketplace. Maintainers review pull requests, triage issues and manage releases.
+- **Contributors** – anyone submitting patches or issues via GitHub.
+
+## Decision-Making Process
+
+1. All changes are proposed through GitHub pull requests.
+2. A pull request requires approval from at least two maintainers before merging.
+3. Discussions take place in issues or pull request threads. Consensus is reached when no maintainer objects for 48 hours after the last approval.
+
+## Quorum
+
+For decisions involving new features, releases or policy updates, a quorum of two maintainers is required. If fewer than two maintainers are active, project owners may appoint additional maintainers.
+
+## Dispute Resolution
+
+If maintainers disagree and cannot reach consensus, project owners from PositiveWeb3 make the final call.
+

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ We welcome your feedback and contributions to improve this extension!
 
 - File issues and suggestions [on GitHub](https://github.com/PositiveSecurity/ton-graph/issues)
 - Fork the repository and submit pull requests
+- Review the [security policy](SECURITY.md) for vulnerability reporting instructions
+- Project decision-making is documented in [GOVERNANCE.md](GOVERNANCE.md)
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,3 +7,10 @@ The implementation in [src/secrets/tokenManager.ts](src/secrets/tokenManager.ts)
 invokes `context.secrets.get`, `context.secrets.store`, and `context.secrets.delete` to
 retrieve, save, and remove the key. VS Code encrypts these secrets on disk, so no
 API keys are written to the extension's configuration files or logs.
+
+## Emergency Update Procedure
+
+If a critical vulnerability is discovered, maintainers will publish an immediate patch release on the `main` branch and the VS Code Marketplace. Users should update the extension as soon as possible.
+
+If necessary, the extension can be temporarily disabled from VS Code by selecting **Disable** in the Extensions view. Maintainers may also remove the extension from the marketplace until the issue is resolved.
+


### PR DESCRIPTION
## Summary
- document project governance model
- describe an emergency update procedure
- link to governance and security policies from README

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684345d4bda08328b946c12bbf9c8cd2