### PR TITLE
Add Move analyzer path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 3. Search for "TON Graph"
 4. Click Install
 5. Run "TON Graph: Set API Key" from the command palette and enter your Toncenter API key
-6. Install the `move-analyzer` binary and ensure it is available in your PATH (required for Move support)
+6. Install the `move-analyzer` binary and ensure it is available in your PATH (required for Move support). If the binary is located elsewhere, set the `ton-graph.moveAnalyzerPath` setting to its full path.
 
 ## Usage
 
@@ -184,6 +184,10 @@ You can also view logs directly in VS Code under **Output** → **TON Graph**.
 ## Requirements
 
  - Visual Studio Code 1.75.0 or newer
+
+## Configuration
+
+- `ton-graph.moveAnalyzerPath` – path to the `move-analyzer` executable used for Move language support. Defaults to `move-analyzer`.
 
 ## Limitations
 

--- a/package.json
+++ b/package.json
@@ -135,6 +135,16 @@
           "group": "navigation"
         }
       ]
+    },
+    "configuration": {
+      "title": "TON Graph",
+      "properties": {
+        "ton-graph.moveAnalyzerPath": {
+          "type": "string",
+          "default": "move-analyzer",
+          "description": "Path to the Move analyzer executable"
+        }
+      }
     }
   },
   "scripts": {

--- a/src/lsp-clients/moveClient.ts
+++ b/src/lsp-clients/moveClient.ts
@@ -3,13 +3,30 @@ import * as vscode from 'vscode';
 import { LanguageClient, StreamInfo } from 'vscode-languageclient/node';
 
 export function startMoveClient(context: vscode.ExtensionContext): vscode.Disposable {
-  const proc = child_process.spawn('move-analyzer', ['--lsp'], {
-    stdio: 'pipe'
+  const moveAnalyzerPath = vscode.workspace
+    .getConfiguration('ton-graph')
+    .get<string>('moveAnalyzerPath', 'move-analyzer');
+
+  let proc: child_process.ChildProcess;
+  try {
+    proc = child_process.spawn(moveAnalyzerPath, ['--lsp'], {
+      stdio: 'pipe'
+    });
+  } catch (err) {
+    const message = `Failed to start move-analyzer: ${err instanceof Error ? err.message : err}`;
+    vscode.window.showErrorMessage(message);
+    return new vscode.Disposable(() => {});
+  }
+
+  proc.on('error', err => {
+    vscode.window.showErrorMessage(`move-analyzer error: ${err.message}`);
   });
-  const serverOptions = () => Promise.resolve<StreamInfo>({
-    reader: proc.stdout!,
-    writer: proc.stdin!
-  });
+
+  const serverOptions = () =>
+    Promise.resolve<StreamInfo>({
+      reader: proc.stdout!,
+      writer: proc.stdin!
+    });
   const client = new LanguageClient('move', 'Move Analyzer', serverOptions, {
     documentSelector: [{ scheme: 'file', language: 'move' }]
   });


### PR DESCRIPTION
## Summary
- add `moveAnalyzerPath` setting to VS Code extension
- read the new configuration in `startMoveClient`
- show errors when the `move-analyzer` process fails to start
- document the new setting in README

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434bd2f724832891f6b1bd597c786e