### PR TITLE
Use toml parser for Move dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "vscode-languageclient": "^9.0.1",
         "web-tree-sitter": "^0.25.6",
         "winston": "^3.17.0",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "toml": "^3.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.8.1",
@@ -14623,6 +14624,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.55",

--- a/package.json
+++ b/package.json
@@ -207,7 +207,8 @@
     "vscode-languageclient": "^9.0.1",
     "web-tree-sitter": "^0.25.6",
     "winston": "^3.17.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "toml": "^3.0.0"
   },
   "files": [
     "out/**/*",


### PR DESCRIPTION
## Summary
- parse Move.toml using `toml.parse`
- log an error when Move.toml is invalid
- depend on the `toml` package
- add regression test for multiple Move dependencies with comments

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843505ecc1c8328a9c169a989937ded