### PR TITLE
Add tests for simple language adapters

### DIFF
--- a/test/cadenceParser.test.ts
+++ b/test/cadenceParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseCadenceContract } from '../src/languages/cadence';
+
+describe('parseCadenceContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'pub fun bar() {}',
+      'pub fun foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseCadenceContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});

--- a/test/cairoParser.test.ts
+++ b/test/cairoParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseCairoContract } from '../src/languages/cairo';
+
+describe('parseCairoContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'func bar() {}',
+      'func foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseCairoContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});

--- a/test/michelsonParser.test.ts
+++ b/test/michelsonParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseMichelsonContract } from '../src/languages/michelson';
+
+describe('parseMichelsonContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'func bar() {}',
+      'func foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseMichelsonContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});

--- a/test/plutusParser.test.ts
+++ b/test/plutusParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parsePlutusContract } from '../src/languages/plutus';
+
+describe('parsePlutusContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'fun bar() {}',
+      'fun foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parsePlutusContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- test Cairo parsing
- test Cadence parsing
- test Michelson parsing
- test Plutus parsing

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684365f7aef88328a7c9f2c31588d0fa