### PR TITLE
Update docs for new language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ## [Unreleased]
 - Added Move language support via `move-analyzer`.
+- Added Cairo, Plutus, Cadence and Michelson language support.
 - Updated documentation and package description.
 - Added example Move contracts under `examples/move/`.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence and Michelson
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">
@@ -188,6 +189,7 @@ You can also view logs directly in VS Code under **Output** → **TON Graph**.
 ## Requirements
 
  - Visual Studio Code 1.75.0 or newer
+ - [`move-analyzer`](https://github.com/move-language/move/tree/main/language/move-analyzer) installed and available in your `PATH` for Move contract support
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- document new Cairo, Plutus, Cadence and Michelson languages in README
- explain move-analyzer requirement in README
- mention new language support in CHANGELOG

## Testing
- `npm ci` *(fails: nyc not found)*
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c3873a0c8328b003976b5d3cd779