### PR TITLE
Handle Move generics in call graph

### DIFF
--- a/src/parser/moveParser.ts
+++ b/src/parser/moveParser.ts
@@ -166,9 +166,13 @@ export async function parseMoveContract(code: string): Promise<ContractGraph> {
       const from = `${m.name}::${f.name}`;
       const calls = walk(f.body, 'call_expression');
       for (const call of calls) {
-        const access = call.namedChildren[0]?.namedChildren?.find((c: any) => c.fieldName === 'access') || call.childForFieldName('access');
+        const access =
+          call.namedChildren[0]?.namedChildren?.find(
+            (c: any) => c.fieldName === 'access'
+          ) || call.childForFieldName('access');
         let path = access ? access.text : '';
         if (!path) continue;
+        path = path.replace(/<.*>$/, '');
         if (!path.includes('::')) {
           path = useMap.get(path) || `${m.name}::${path}`;
         }

--- a/test/moveParser.test.ts
+++ b/test/moveParser.test.ts
@@ -21,6 +21,18 @@ const modifierSample = `module M {
     public(script) fun run() {}
 }`;
 
+const genericSample = `module M {
+    fun init() {
+        transfer<u8>();
+    }
+
+    fun transfer<T>() {
+        credit<T>();
+    }
+
+    fun credit<T>() {}
+}`;
+
 describe('parseMoveContract', () => {
     it('parses functions and edges', async () => {
         const graph = await parseMoveContract(sample);
@@ -61,6 +73,16 @@ describe('parseMoveContract', () => {
             { alias: 'Self', path: 'std::option::Self' },
             { alias: 'Opt', path: 'std::option::Option' },
             { alias: 'Baz', path: '0x1::foo::Bar' }
+        ]);
+    });
+
+    it('resolves generic calls to function ids', async () => {
+        const graph = await parseMoveContract(genericSample);
+        const ids = graph.nodes.map(n => n.id);
+        expect(ids).to.have.members(['M::init', 'M::transfer', 'M::credit']);
+        expect(graph.edges).to.deep.include.members([
+            { from: 'M::init', to: 'M::transfer', label: '' },
+            { from: 'M::transfer', to: 'M::credit', label: '' }
         ]);
     });
 });


### PR DESCRIPTION
## Summary
- strip `<...>` generics from Move call paths
- test Move parser with generic calls

## Testing
- `npm test` *(fails: Property 'source' does not exist on type 'string | RegExp')*

------
https://chatgpt.com/codex/tasks/task_e_6843cbb60c288328b8ee8a3be2057e16