### PR TITLE
Handle Move friend access modifier

### DIFF
--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -196,7 +196,9 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
             return [
                 { value: 'regular', label: 'Regular' },
                 { value: 'entry', label: 'Entry' },
-                { value: 'script', label: 'Script' }
+                { value: 'script', label: 'Script' },
+                { value: 'public', label: 'Public' },
+                { value: 'friend', label: 'Friend' }
             ];
         case 'cairo':
         case 'plutus':


### PR DESCRIPTION
## Summary
- detect `public(friend)` functions using AST children
- tag these as `friend` type functions when building graphs
- expose `friend` and `public` filters for Move graphs

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843cd5661b88328a435d10a9897741e