### PR TITLE
Fix duplicate edges in call graphs

### DIFF
--- a/src/parser/moveParser.ts
+++ b/src/parser/moveParser.ts
@@ -144,6 +144,7 @@ export async function parseMoveContract(code: string): Promise<ContractGraph> {
   const { ast } = parseMove(code);
   const graph: ContractGraph = { nodes: [], edges: [] };
   const funcMap = new Map<string, ContractNode>();
+  const edgeSet = new Set<string>();
 
   for (const m of ast.modules) {
     for (const f of m.functions) {
@@ -190,11 +191,20 @@ export async function parseMoveContract(code: string): Promise<ContractGraph> {
           path = useMap.get(path) || `${m.name}::${path}`;
         }
         const to = path;
-        if (!funcMap.has(to)) {
-          graph.nodes.push({ id: to, label: path, type: GraphNodeKind.Function, contractName: path.split('::')[path.split('::').length - 2] || path });
-          funcMap.set(to, graph.nodes[graph.nodes.length - 1]);
+        const key = `${from}->${to}`;
+        if (!edgeSet.has(key)) {
+          edgeSet.add(key);
+          if (!funcMap.has(to)) {
+            graph.nodes.push({
+              id: to,
+              label: path,
+              type: GraphNodeKind.Function,
+              contractName: path.split('::')[path.split('::').length - 2] || path
+            });
+            funcMap.set(to, graph.nodes[graph.nodes.length - 1]);
+          }
+          graph.edges.push({ from, to, label: '' });
         }
-        graph.edges.push({ from, to, label: '' });
       }
     }
   }

--- a/test/cairoParser.test.ts
+++ b/test/cairoParser.test.ts
@@ -16,4 +16,16 @@ describe('parseCairoContract', () => {
     expect(ids).to.have.members(['bar', 'foo']);
     expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
   });
+
+  it('ignores duplicate calls', () => {
+    const code = [
+      'func bar() {}',
+      'func foo() {',
+      '  bar();',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseCairoContract(code);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
 });

--- a/test/moveParser.test.ts
+++ b/test/moveParser.test.ts
@@ -33,6 +33,15 @@ const genericSample = `module M {
     fun credit<T>() {}
 }`;
 
+const duplicateSample = `module M {
+    fun init() {
+        transfer();
+        transfer();
+    }
+
+    fun transfer() {}
+}`;
+
 describe('parseMoveContract', () => {
     it('parses functions and edges', async () => {
         const graph = await parseMoveContract(sample);
@@ -83,6 +92,13 @@ describe('parseMoveContract', () => {
         expect(graph.edges).to.deep.include.members([
             { from: 'M::init', to: 'M::transfer', label: '' },
             { from: 'M::transfer', to: 'M::credit', label: '' }
+        ]);
+    });
+
+    it('does not create duplicate edges', async () => {
+        const graph = await parseMoveContract(duplicateSample);
+        expect(graph.edges).to.deep.equal([
+            { from: 'M::init', to: 'M::transfer', label: '' }
         ]);
     });
 });


### PR DESCRIPTION
## Summary
- deduplicate edges when building simple graphs
- avoid duplicate Move edges and only create needed placeholder nodes
- test repeated call handling for Move and Cairo parsers

## Testing
- `npm install --ignore-scripts`
- `TS_NODE_TRANSPILE_ONLY=1 npm test` *(fails: No native build for tree-sitter-move)*

------
https://chatgpt.com/codex/tasks/task_e_6843d155d240832881bdbc63630e50b9