### PR TITLE
Handle Move parse failures gracefully

### DIFF
--- a/src/parser/moveParser.ts
+++ b/src/parser/moveParser.ts
@@ -2,6 +2,7 @@ import Parser from 'tree-sitter';
 import Move from 'tree-sitter-move';
 import { ContractGraph, ContractNode } from '../types/graph';
 import { GraphNodeKind } from '../types/graphNodeKind';
+import logger from '../logging/logger';
 
 export interface MoveImport {
   alias: string;
@@ -50,7 +51,14 @@ function findNodes(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode[] {
 
 export function parseMove(code: string): { ast: MoveAST; tree: Parser.Tree } {
   const p = getParser();
-  const tree = p.parse(code);
+  let tree: Parser.Tree;
+  try {
+    tree = p.parse(code);
+  } catch (err) {
+    logger.error('Error parsing Move code', err);
+    tree = p.parse('');
+    return { ast: { modules: [] }, tree };
+  }
   const modules: MoveModule[] = [];
   for (const moduleNode of findNodes(tree.rootNode, 'module_definition')) {
     const idNode = moduleNode.childForFieldName('module_identity');

--- a/test/moveParser.test.ts
+++ b/test/moveParser.test.ts
@@ -101,4 +101,10 @@ describe('parseMoveContract', () => {
             { from: 'M::init', to: 'M::transfer', label: '' }
         ]);
     });
+
+    it('returns empty graph on malformed code', async () => {
+        const graph = await parseMoveContract('module {');
+        expect(graph.nodes).to.be.empty;
+        expect(graph.edges).to.be.empty;
+    });
 });


### PR DESCRIPTION
## Summary
- avoid crashing Move parser when tree-sitter throws
- record parser error via logger and fall back to an empty AST
- test that malformed Move code returns an empty graph

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d363db688328bd3d359c05af18b3