### PR TITLE
Add simple adapters for Clar, ink and Scilla

### DIFF
--- a/src/languages/clar/index.ts
+++ b/src/languages/clar/index.ts
@@ -1,0 +1,24 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST } from '../simple';
+import { simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseClar(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:fn|function|def|define)/);
+}
+
+export const clarAdapter: LanguageAdapter = {
+  fileExtensions: ['.clar'],
+  parse(source: string): AST {
+    return parseClar(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default clarAdapter;
+
+export function parseClarContract(code: string): ContractGraph {
+  const ast = parseClar(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -4,6 +4,9 @@ import cairoAdapter from './cairo';
 import plutusAdapter from './plutus';
 import cadenceAdapter from './cadence';
 import michelsonAdapter from './michelson';
+import clarAdapter from './clar';
+import inkAdapter from './ink';
+import scillaAdapter from './scilla';
 
 const adapters = [
   ...adaptersFunc,
@@ -11,8 +14,20 @@ const adapters = [
   cairoAdapter,
   plutusAdapter,
   cadenceAdapter,
-  michelsonAdapter
+  michelsonAdapter,
+  clarAdapter,
+  inkAdapter,
+  scillaAdapter
 ];
 
 export default adapters;
-export { cairoAdapter, plutusAdapter, cadenceAdapter, michelsonAdapter, movelangAdapter };
+export {
+  cairoAdapter,
+  plutusAdapter,
+  cadenceAdapter,
+  michelsonAdapter,
+  movelangAdapter,
+  clarAdapter,
+  inkAdapter,
+  scillaAdapter
+};

--- a/src/languages/ink/index.ts
+++ b/src/languages/ink/index.ts
@@ -1,0 +1,24 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST } from '../simple';
+import { simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseInk(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:fn)/);
+}
+
+export const inkAdapter: LanguageAdapter = {
+  fileExtensions: ['.ink'],
+  parse(source: string): AST {
+    return parseInk(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default inkAdapter;
+
+export function parseInkContract(code: string): ContractGraph {
+  const ast = parseInk(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/languages/scilla/index.ts
+++ b/src/languages/scilla/index.ts
@@ -1,0 +1,24 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST } from '../simple';
+import { simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseScilla(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:transition|procedure|function|def)/);
+}
+
+export const scillaAdapter: LanguageAdapter = {
+  fileExtensions: ['.scilla'],
+  parse(source: string): AST {
+    return parseScilla(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default scillaAdapter;
+
+export function parseScillaContract(code: string): ContractGraph {
+  const ast = parseScilla(code);
+  return simpleAstToGraph(ast);
+}

--- a/test/clarParser.test.ts
+++ b/test/clarParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseClarContract } from '../src/languages/clar';
+
+describe('parseClarContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'function bar() {}',
+      'function foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseClarContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});

--- a/test/inkParser.test.ts
+++ b/test/inkParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseInkContract } from '../src/languages/ink';
+
+describe('parseInkContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'fn bar() {}',
+      'fn foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseInkContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});

--- a/test/scillaParser.test.ts
+++ b/test/scillaParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseScillaContract } from '../src/languages/scilla';
+
+describe('parseScillaContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'transition bar() {}',
+      'transition foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseScillaContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Clar adapter and parser helper
- add ink adapter and parser helper
- add Scilla adapter and parser helper
- expose new adapters in language index
- test parsing for Clar, ink and Scilla

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d714fa188328b72081353a2efb9d