### PR TITLE
Add tolk parser unit test

### DIFF
--- a/test/tolkParser.test.ts
+++ b/test/tolkParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { activeTextEditor: undefined, createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseTolkContract } from '../src/languages/func/tolkParser';
+
+describe('parseTolkContract', () => {
+  it('parses functions and edges', async () => {
+    const code = [
+      'fun bar() {}',
+      'fun foo() {',
+      '  bar();',
+      '}',
+    ].join('\n');
+    const graph = await parseTolkContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `tolkParser.test.ts` verifying nodes and edges returned by `parseTolkContract`

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e01b53348328b4a24ea67bc5d3d1