### PR TITLE
Add Pact language parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink and Scilla.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla and Pact.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -28,6 +28,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Clarity (\*.clar)
   - Ink (\*.ink)
   - Scilla (\*.scilla)
+  - Pact (\*.pact)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -56,7 +57,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 ## Usage
 
-1. Open a contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink or \*.scilla)
+1. Open a contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla or \*.pact)
    Note: Move contracts are parsed via `move-analyzer`.
 2. You can visualize a contract in multiple ways:
    - Press F1 or Ctrl+Shift+P to open the command palette and type "TON Graph: Visualize Contract"
@@ -68,7 +69,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 You can also visualize an entire contract including all imports:
 
-1. Open a main contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink or \*.scilla)
+1. Open a main contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla or \*.pact)
 2. Visualize the project in one of these ways:
    - Press F1 or Ctrl+Shift+P and type "TON Graph: Visualize Contract with Imports"
    - Right-click on contract code in the editor → TON Graph: Visualize Contract with Imports
@@ -112,7 +113,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink and Scilla
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla and Pact
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/pact/hello.pact
+++ b/examples/pact/hello.pact
@@ -1,0 +1,5 @@
+(defun bar ()
+  (format "hello"))
+
+(defun foo ()
+  (bar))

--- a/marketplace-description.md
+++ b/marketplace-description.md
@@ -1,1 +1,1 @@
-Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, and Scilla contracts. Move support requires the move-analyzer tool.
+Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, and Pact contracts. Move support requires the move-analyzer tool.

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "onLanguage:michelson",
     "onLanguage:clar",
     "onLanguage:ink",
-    "onLanguage:scilla"
+    "onLanguage:scilla",
+    "onLanguage:pact"
   ],
   "contributes": {
     "languages": [
@@ -144,6 +145,15 @@
         "aliases": [
           "Scilla"
         ]
+      },
+      {
+        "id": "pact",
+        "extensions": [
+          ".pact"
+        ],
+        "aliases": [
+          "Pact"
+        ]
       }
     ],
     "commands": [
@@ -184,24 +194,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -7,6 +7,7 @@ import michelsonAdapter from './michelson';
 import clarAdapter from './clar';
 import inkAdapter from './ink';
 import scillaAdapter from './scilla';
+import pactAdapter from './pact';
 
 const adapters = [
   ...adaptersFunc,
@@ -17,7 +18,8 @@ const adapters = [
   michelsonAdapter,
   clarAdapter,
   inkAdapter,
-  scillaAdapter
+  scillaAdapter,
+  pactAdapter
 ];
 
 export default adapters;
@@ -29,5 +31,6 @@ export {
   movelangAdapter,
   clarAdapter,
   inkAdapter,
-  scillaAdapter
+  scillaAdapter,
+  pactAdapter
 };

--- a/src/languages/pact/index.ts
+++ b/src/languages/pact/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parsePact(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:defun|defpact|defcap)/);
+}
+
+export const pactAdapter: LanguageAdapter = {
+  fileExtensions: ['.pact'],
+  parse(source: string): AST {
+    return parsePact(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default pactAdapter;
+
+export function parsePactContract(code: string): ContractGraph {
+  const ast = parsePact(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -12,6 +12,7 @@ import { parseMichelsonContract } from '../languages/michelson';
 import { parseClarContract } from '../languages/clar';
 import { parseInkContract } from '../languages/ink';
 import { parseScillaContract } from '../languages/scilla';
+import { parsePactContract } from '../languages/pact';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -35,7 +36,8 @@ export type ContractLanguage =
   | 'michelson'
   | 'clar'
   | 'ink'
-  | 'scilla';
+  | 'scilla'
+  | 'pact';
 
 /**
  * Detects the language based on file extension
@@ -64,6 +66,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
         return 'ink';
     } else if (extension === '.scilla') {
         return 'scilla';
+    } else if (extension === '.pact') {
+        return 'pact';
     }
 
     // Default to FunC
@@ -109,6 +113,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'scilla':
             graph = parseScillaContract(code);
+            break;
+        case 'pact':
+            graph = parsePactContract(code);
             break;
         case 'func':
         default:
@@ -228,6 +235,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'clar':
         case 'ink':
         case 'scilla':
+        case 'pact':
             return [
                 { value: 'regular', label: 'Regular' }
             ];

--- a/test/pactParser.test.ts
+++ b/test/pactParser.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parsePactContract } from '../src/languages/pact';
+
+describe('parsePactContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      '(defun bar () (format "hello"))',
+      '(defun foo ()',
+      '  (bar))'
+    ].join('\n');
+    const graph = parsePactContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Pact parser adapter and contract graph converter
- detect `.pact` files and treat them as Pact language
- include Pact in UI lists and VS Code language contributions
- provide example `hello.pact` contract
- support Pact in parser utilities and tests
- document Pact support in README and marketplace description

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e86ba89c832888650dd46bd65ca3