### PR TITLE
Add Scrypto language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla and Pact.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact and Scrypto.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -29,6 +29,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Ink (\*.ink)
   - Scilla (\*.scilla)
   - Pact (\*.pact)
+  - Scrypto (\*.rs, \*.scrypto)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -113,7 +114,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla and Pact
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact and Scrypto
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/scrypto/hello.rs
+++ b/examples/scrypto/hello.rs
@@ -1,0 +1,5 @@
+fn bar() {}
+
+fn foo() {
+    bar();
+}

--- a/marketplace-description.md
+++ b/marketplace-description.md
@@ -1,1 +1,1 @@
-Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, and Pact contracts. Move support requires the move-analyzer tool.
+Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact and Scrypto contracts. Move support requires the move-analyzer tool.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "onLanguage:clar",
     "onLanguage:ink",
     "onLanguage:scilla",
-    "onLanguage:pact"
+    "onLanguage:pact",
+    "onLanguage:scrypto"
   ],
   "contributes": {
     "languages": [
@@ -154,6 +155,16 @@
         "aliases": [
           "Pact"
         ]
+      },
+      {
+        "id": "scrypto",
+        "extensions": [
+          ".rs",
+          ".scrypto"
+        ],
+        "aliases": [
+          "Scrypto"
+        ]
       }
     ],
     "commands": [
@@ -194,24 +205,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -8,6 +8,7 @@ import clarAdapter from './clar';
 import inkAdapter from './ink';
 import scillaAdapter from './scilla';
 import pactAdapter from './pact';
+import scryptoAdapter from './scrypto';
 
 const adapters = [
   ...adaptersFunc,
@@ -19,7 +20,8 @@ const adapters = [
   clarAdapter,
   inkAdapter,
   scillaAdapter,
-  pactAdapter
+  pactAdapter,
+  scryptoAdapter
 ];
 
 export default adapters;
@@ -32,5 +34,6 @@ export {
   clarAdapter,
   inkAdapter,
   scillaAdapter,
-  pactAdapter
+  pactAdapter,
+  scryptoAdapter
 };

--- a/src/languages/scrypto/index.ts
+++ b/src/languages/scrypto/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseScrypto(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:fn)/);
+}
+
+export const scryptoAdapter: LanguageAdapter = {
+  fileExtensions: ['.rs', '.scrypto'],
+  parse(source: string): AST {
+    return parseScrypto(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default scryptoAdapter;
+
+export function parseScryptoContract(code: string): ContractGraph {
+  const ast = parseScrypto(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -13,6 +13,7 @@ import { parseClarContract } from '../languages/clar';
 import { parseInkContract } from '../languages/ink';
 import { parseScillaContract } from '../languages/scilla';
 import { parsePactContract } from '../languages/pact';
+import { parseScryptoContract } from '../languages/scrypto';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -37,7 +38,8 @@ export type ContractLanguage =
   | 'clar'
   | 'ink'
   | 'scilla'
-  | 'pact';
+  | 'pact'
+  | 'scrypto';
 
 /**
  * Detects the language based on file extension
@@ -64,11 +66,13 @@ export function detectLanguage(filePath: string): ContractLanguage {
         return 'clar';
     } else if (extension === '.ink') {
         return 'ink';
-    } else if (extension === '.scilla') {
-        return 'scilla';
-    } else if (extension === '.pact') {
-        return 'pact';
-    }
+  } else if (extension === '.scilla') {
+      return 'scilla';
+  } else if (extension === '.pact') {
+      return 'pact';
+  } else if (extension === '.scrypto' || extension === '.rs') {
+      return 'scrypto';
+  }
 
     // Default to FunC
     return 'func';
@@ -110,6 +114,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'ink':
             graph = parseInkContract(code);
+            break;
+        case 'scrypto':
+            graph = parseScryptoContract(code);
             break;
         case 'scilla':
             graph = parseScillaContract(code);
@@ -234,6 +241,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'michelson':
         case 'clar':
         case 'ink':
+        case 'scrypto':
         case 'scilla':
         case 'pact':
             return [

--- a/test/scryptoParser.test.ts
+++ b/test/scryptoParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseScryptoContract } from '../src/languages/scrypto';
+
+describe('parseScryptoContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'fn bar() {}',
+      'fn foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseScryptoContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Scrypto parser using `parseSimpleFunctions`
- register `scryptoAdapter`
- detect `.rs` and `.scrypto` files
- return appropriate function filters
- enable Scrypto in package activation and menus
- document Scrypto in README and marketplace description
- provide Scrypto example and parser test

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843eb640940832891d2002b356d0590