### PR TITLE
Add LIGO language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact and Scrypto.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto and LIGO.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -30,6 +30,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Scilla (\*.scilla)
   - Pact (\*.pact)
   - Scrypto (\*.rs, \*.scrypto)
+  - LIGO (\*.ligo, \*.mligo, \*.jsligo, \*.religo)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -58,7 +59,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 ## Usage
 
-1. Open a contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla or \*.pact)
+1. Open a contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact or \*.ligo)
    Note: Move contracts are parsed via `move-analyzer`.
 2. You can visualize a contract in multiple ways:
    - Press F1 or Ctrl+Shift+P to open the command palette and type "TON Graph: Visualize Contract"
@@ -70,7 +71,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 You can also visualize an entire contract including all imports:
 
-1. Open a main contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla or \*.pact)
+1. Open a main contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact or \*.ligo)
 2. Visualize the project in one of these ways:
    - Press F1 or Ctrl+Shift+P and type "TON Graph: Visualize Contract with Imports"
    - Right-click on contract code in the editor → TON Graph: Visualize Contract with Imports
@@ -114,7 +115,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact and Scrypto
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto and LIGO
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/ligo/hello.ligo
+++ b/examples/ligo/hello.ligo
@@ -1,0 +1,7 @@
+function bar() : unit is {
+  skip;
+}
+
+function foo() : unit is {
+  bar();
+}

--- a/marketplace-description.md
+++ b/marketplace-description.md
@@ -1,1 +1,1 @@
-Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact and Scrypto contracts. Move support requires the move-analyzer tool.
+Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto and LIGO contracts. Move support requires the move-analyzer tool.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "onLanguage:ink",
     "onLanguage:scilla",
     "onLanguage:pact",
-    "onLanguage:scrypto"
+    "onLanguage:scrypto",
+    "onLanguage:ligo"
   ],
   "contributes": {
     "languages": [
@@ -165,6 +166,18 @@
         "aliases": [
           "Scrypto"
         ]
+      },
+      {
+        "id": "ligo",
+        "extensions": [
+          ".ligo",
+          ".mligo",
+          ".religo",
+          ".jsligo"
+        ],
+        "aliases": [
+          "LIGO"
+        ]
       }
     ],
     "commands": [
@@ -205,24 +218,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -9,6 +9,7 @@ import inkAdapter from './ink';
 import scillaAdapter from './scilla';
 import pactAdapter from './pact';
 import scryptoAdapter from './scrypto';
+import ligoAdapter from './ligo';
 
 const adapters = [
   ...adaptersFunc,
@@ -21,7 +22,8 @@ const adapters = [
   inkAdapter,
   scillaAdapter,
   pactAdapter,
-  scryptoAdapter
+  scryptoAdapter,
+  ligoAdapter
 ];
 
 export default adapters;
@@ -35,5 +37,6 @@ export {
   inkAdapter,
   scillaAdapter,
   pactAdapter,
-  scryptoAdapter
+  scryptoAdapter,
+  ligoAdapter
 };

--- a/src/languages/ligo/index.ts
+++ b/src/languages/ligo/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseLigo(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:function|let)/);
+}
+
+export const ligoAdapter: LanguageAdapter = {
+  fileExtensions: ['.ligo', '.mligo', '.religo', '.jsligo'],
+  parse(source: string): AST {
+    return parseLigo(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default ligoAdapter;
+
+export function parseLigoContract(code: string): ContractGraph {
+  const ast = parseLigo(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -14,6 +14,7 @@ import { parseInkContract } from '../languages/ink';
 import { parseScillaContract } from '../languages/scilla';
 import { parsePactContract } from '../languages/pact';
 import { parseScryptoContract } from '../languages/scrypto';
+import { parseLigoContract } from '../languages/ligo';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -39,7 +40,8 @@ export type ContractLanguage =
   | 'ink'
   | 'scilla'
   | 'pact'
-  | 'scrypto';
+  | 'scrypto'
+  | 'ligo';
 
 /**
  * Detects the language based on file extension
@@ -72,6 +74,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'pact';
   } else if (extension === '.scrypto' || extension === '.rs') {
       return 'scrypto';
+  } else if (extension === '.ligo' || extension === '.mligo' || extension === '.religo' || extension === '.jsligo') {
+      return 'ligo';
   }
 
     // Default to FunC
@@ -123,6 +127,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'pact':
             graph = parsePactContract(code);
+            break;
+        case 'ligo':
+            graph = parseLigoContract(code);
             break;
         case 'func':
         default:
@@ -244,6 +251,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'scrypto':
         case 'scilla':
         case 'pact':
+        case 'ligo':
             return [
                 { value: 'regular', label: 'Regular' }
             ];

--- a/test/ligoParser.test.ts
+++ b/test/ligoParser.test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseLigoContract } from '../src/languages/ligo';
+
+describe('parseLigoContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'function bar() : unit is {',
+      '  skip;',
+      '}',
+      'function foo() : unit is {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseLigoContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- support parsing LIGO files
- detect `.ligo`, `.mligo`, `.religo` and `.jsligo`
- expose new adapter and functions
- document new language
- provide example and tests

## Testing
- `npm ci --ignore-scripts`
- `npm test` *(fails: Module 'tree-sitter' can only be default-imported using the 'esModuleInterop' flag)*

------
https://chatgpt.com/codex/tasks/task_e_6843ed14c7fc8328aeb2a90dd8228bdd