### PR TITLE
Add Aiken language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto and LIGO.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO and Aiken.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -31,6 +31,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Pact (\*.pact)
   - Scrypto (\*.rs, \*.scrypto)
   - LIGO (\*.ligo, \*.mligo, \*.jsligo, \*.religo)
+  - Aiken (\*.ak, \*.aiken)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -59,7 +60,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 ## Usage
 
-1. Open a contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact or \*.ligo)
+1. Open a contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact, \*.ligo or \*.ak)
    Note: Move contracts are parsed via `move-analyzer`.
 2. You can visualize a contract in multiple ways:
    - Press F1 or Ctrl+Shift+P to open the command palette and type "TON Graph: Visualize Contract"
@@ -71,7 +72,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 You can also visualize an entire contract including all imports:
 
-1. Open a main contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact or \*.ligo)
+1. Open a main contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact, \*.ligo or \*.ak)
 2. Visualize the project in one of these ways:
    - Press F1 or Ctrl+Shift+P and type "TON Graph: Visualize Contract with Imports"
    - Right-click on contract code in the editor → TON Graph: Visualize Contract with Imports

--- a/examples/aiken/hello.ak
+++ b/examples/aiken/hello.ak
@@ -1,0 +1,5 @@
+fn bar() {}
+
+fn foo() {
+  bar();
+}

--- a/marketplace-description.md
+++ b/marketplace-description.md
@@ -1,1 +1,1 @@
-Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto and LIGO contracts. Move support requires the move-analyzer tool.
+Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO and Aiken contracts. Move support requires the move-analyzer tool.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "onLanguage:scilla",
     "onLanguage:pact",
     "onLanguage:scrypto",
-    "onLanguage:ligo"
+    "onLanguage:ligo",
+    "onLanguage:aiken"
   ],
   "contributes": {
     "languages": [
@@ -179,6 +180,17 @@
           "LIGO"
         ]
       }
+      ,
+      {
+        "id": "aiken",
+        "extensions": [
+          ".ak",
+          ".aiken"
+        ],
+        "aliases": [
+          "Aiken"
+        ]
+      }
     ],
     "commands": [
       {
@@ -218,24 +230,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo || resourceLangId == aiken",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo || resourceLangId == aiken",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken",
           "group": "navigation"
         }
       ]

--- a/src/languages/aiken/index.ts
+++ b/src/languages/aiken/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseAiken(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:fn)/);
+}
+
+export const aikenAdapter: LanguageAdapter = {
+  fileExtensions: ['.ak', '.aiken'],
+  parse(source: string): AST {
+    return parseAiken(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default aikenAdapter;
+
+export function parseAikenContract(code: string): ContractGraph {
+  const ast = parseAiken(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -10,6 +10,7 @@ import scillaAdapter from './scilla';
 import pactAdapter from './pact';
 import scryptoAdapter from './scrypto';
 import ligoAdapter from './ligo';
+import aikenAdapter from './aiken';
 
 const adapters = [
   ...adaptersFunc,
@@ -23,7 +24,8 @@ const adapters = [
   scillaAdapter,
   pactAdapter,
   scryptoAdapter,
-  ligoAdapter
+  ligoAdapter,
+  aikenAdapter
 ];
 
 export default adapters;
@@ -38,5 +40,6 @@ export {
   scillaAdapter,
   pactAdapter,
   scryptoAdapter,
-  ligoAdapter
+  ligoAdapter,
+  aikenAdapter
 };

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -15,6 +15,7 @@ import { parseScillaContract } from '../languages/scilla';
 import { parsePactContract } from '../languages/pact';
 import { parseScryptoContract } from '../languages/scrypto';
 import { parseLigoContract } from '../languages/ligo';
+import { parseAikenContract } from '../languages/aiken';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -41,7 +42,8 @@ export type ContractLanguage =
   | 'scilla'
   | 'pact'
   | 'scrypto'
-  | 'ligo';
+  | 'ligo'
+  | 'aiken';
 
 /**
  * Detects the language based on file extension
@@ -76,6 +78,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'scrypto';
   } else if (extension === '.ligo' || extension === '.mligo' || extension === '.religo' || extension === '.jsligo') {
       return 'ligo';
+  } else if (extension === '.ak' || extension === '.aiken') {
+      return 'aiken';
   }
 
     // Default to FunC
@@ -130,6 +134,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'ligo':
             graph = parseLigoContract(code);
+            break;
+        case 'aiken':
+            graph = parseAikenContract(code);
             break;
         case 'func':
         default:
@@ -252,6 +259,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'scilla':
         case 'pact':
         case 'ligo':
+        case 'aiken':
             return [
                 { value: 'regular', label: 'Regular' }
             ];

--- a/test/aikenParser.test.ts
+++ b/test/aikenParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseAikenContract } from '../src/languages/aiken';
+
+describe('parseAikenContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'fn bar() {}',
+      'fn foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseAikenContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement Aiken parser with simple function detection
- register new adapter
- extend language detection and filters for `.ak`/`.aiken`
- update VS Code contributions and docs
- add Aiken example and parser tests

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843eeb8b9648328abd3a9b619562aee