### PR TITLE
Add Leo language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO and Aiken.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO, Aiken and Leo.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -32,6 +32,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Scrypto (\*.rs, \*.scrypto)
   - LIGO (\*.ligo, \*.mligo, \*.jsligo, \*.religo)
   - Aiken (\*.ak, \*.aiken)
+  - Leo (\*.leo)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -60,7 +61,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 ## Usage
 
-1. Open a contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact, \*.ligo or \*.ak)
+1. Open a contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact, \*.ligo, \*.leo or \*.ak)
    Note: Move contracts are parsed via `move-analyzer`.
 2. You can visualize a contract in multiple ways:
    - Press F1 or Ctrl+Shift+P to open the command palette and type "TON Graph: Visualize Contract"
@@ -72,7 +73,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 You can also visualize an entire contract including all imports:
 
-1. Open a main contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact, \*.ligo or \*.ak)
+1. Open a main contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact, \*.ligo, \*.leo or \*.ak)
 2. Visualize the project in one of these ways:
    - Press F1 or Ctrl+Shift+P and type "TON Graph: Visualize Contract with Imports"
    - Right-click on contract code in the editor → TON Graph: Visualize Contract with Imports

--- a/examples/leo/hello.leo
+++ b/examples/leo/hello.leo
@@ -1,0 +1,5 @@
+function bar() {}
+
+function foo() {
+  bar();
+}

--- a/marketplace-description.md
+++ b/marketplace-description.md
@@ -1,1 +1,1 @@
-Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO and Aiken contracts. Move support requires the move-analyzer tool.
+Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO, Aiken and Leo contracts. Move support requires the move-analyzer tool.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "onLanguage:pact",
     "onLanguage:scrypto",
     "onLanguage:ligo",
-    "onLanguage:aiken"
+    "onLanguage:aiken",
+    "onLanguage:leo"
   ],
   "contributes": {
     "languages": [
@@ -190,6 +191,15 @@
         "aliases": [
           "Aiken"
         ]
+      },
+      {
+        "id": "leo",
+        "extensions": [
+          ".leo"
+        ],
+        "aliases": [
+          "Leo"
+        ]
       }
     ],
     "commands": [
@@ -230,24 +240,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo || resourceLangId == aiken",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo || resourceLangId == aiken",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -11,6 +11,7 @@ import pactAdapter from './pact';
 import scryptoAdapter from './scrypto';
 import ligoAdapter from './ligo';
 import aikenAdapter from './aiken';
+import leoAdapter from './leo';
 
 const adapters = [
   ...adaptersFunc,
@@ -25,7 +26,8 @@ const adapters = [
   pactAdapter,
   scryptoAdapter,
   ligoAdapter,
-  aikenAdapter
+  aikenAdapter,
+  leoAdapter
 ];
 
 export default adapters;
@@ -41,5 +43,6 @@ export {
   pactAdapter,
   scryptoAdapter,
   ligoAdapter,
-  aikenAdapter
+  aikenAdapter,
+  leoAdapter
 };

--- a/src/languages/leo/index.ts
+++ b/src/languages/leo/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseLeo(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:function|fn)/);
+}
+
+export const leoAdapter: LanguageAdapter = {
+  fileExtensions: ['.leo'],
+  parse(source: string): AST {
+    return parseLeo(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default leoAdapter;
+
+export function parseLeoContract(code: string): ContractGraph {
+  const ast = parseLeo(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -16,6 +16,7 @@ import { parsePactContract } from '../languages/pact';
 import { parseScryptoContract } from '../languages/scrypto';
 import { parseLigoContract } from '../languages/ligo';
 import { parseAikenContract } from '../languages/aiken';
+import { parseLeoContract } from '../languages/leo';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -43,7 +44,8 @@ export type ContractLanguage =
   | 'pact'
   | 'scrypto'
   | 'ligo'
-  | 'aiken';
+  | 'aiken'
+  | 'leo';
 
 /**
  * Detects the language based on file extension
@@ -80,6 +82,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'ligo';
   } else if (extension === '.ak' || extension === '.aiken') {
       return 'aiken';
+  } else if (extension === '.leo') {
+      return 'leo';
   }
 
     // Default to FunC
@@ -137,6 +141,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'aiken':
             graph = parseAikenContract(code);
+            break;
+        case 'leo':
+            graph = parseLeoContract(code);
             break;
         case 'func':
         default:
@@ -260,6 +267,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'pact':
         case 'ligo':
         case 'aiken':
+        case 'leo':
             return [
                 { value: 'regular', label: 'Regular' }
             ];

--- a/test/leoParser.test.ts
+++ b/test/leoParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseLeoContract } from '../src/languages/leo';
+
+describe('parseLeoContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'function bar() {}',
+      'function foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseLeoContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement parser for Leo using `parseSimpleFunctions`
- export leoAdapter
- detect `.leo` files and parse them
- allow Leo filter types
- add Leo contributions and activation events
- update menus and documentation
- add sample Leo contract and tests

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f1839e4483288f8e72e96940d567