### PR TITLE
Add Soroban language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO, Aiken and Leo.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, LIGO, Aiken and Leo.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -30,6 +30,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Scilla (\*.scilla)
   - Pact (\*.pact)
   - Scrypto (\*.rs, \*.scrypto)
+  - Soroban (\*.soroban)
   - LIGO (\*.ligo, \*.mligo, \*.jsligo, \*.religo)
   - Aiken (\*.ak, \*.aiken)
   - Leo (\*.leo)
@@ -117,7 +118,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto and LIGO
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban and LIGO
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/soroban/hello.soroban
+++ b/examples/soroban/hello.soroban
@@ -1,0 +1,5 @@
+fn bar() {}
+
+fn foo() {
+    bar();
+}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "onLanguage:scilla",
     "onLanguage:pact",
     "onLanguage:scrypto",
+    "onLanguage:soroban",
     "onLanguage:ligo",
     "onLanguage:aiken",
     "onLanguage:leo"
@@ -170,6 +171,15 @@
         ]
       },
       {
+        "id": "soroban",
+        "extensions": [
+          ".soroban"
+        ],
+        "aliases": [
+          "Soroban"
+        ]
+      },
+      {
         "id": "ligo",
         "extensions": [
           ".ligo",
@@ -240,24 +250,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -9,6 +9,7 @@ import inkAdapter from './ink';
 import scillaAdapter from './scilla';
 import pactAdapter from './pact';
 import scryptoAdapter from './scrypto';
+import sorobanAdapter from './soroban';
 import ligoAdapter from './ligo';
 import aikenAdapter from './aiken';
 import leoAdapter from './leo';
@@ -25,6 +26,7 @@ const adapters = [
   scillaAdapter,
   pactAdapter,
   scryptoAdapter,
+  sorobanAdapter,
   ligoAdapter,
   aikenAdapter,
   leoAdapter
@@ -42,6 +44,7 @@ export {
   scillaAdapter,
   pactAdapter,
   scryptoAdapter,
+  sorobanAdapter,
   ligoAdapter,
   aikenAdapter,
   leoAdapter

--- a/src/languages/soroban/index.ts
+++ b/src/languages/soroban/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseSoroban(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:fn)/);
+}
+
+export const sorobanAdapter: LanguageAdapter = {
+  fileExtensions: ['.soroban'],
+  parse(source: string): AST {
+    return parseSoroban(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default sorobanAdapter;
+
+export function parseSorobanContract(code: string): ContractGraph {
+  const ast = parseSoroban(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -14,6 +14,7 @@ import { parseInkContract } from '../languages/ink';
 import { parseScillaContract } from '../languages/scilla';
 import { parsePactContract } from '../languages/pact';
 import { parseScryptoContract } from '../languages/scrypto';
+import { parseSorobanContract } from '../languages/soroban';
 import { parseLigoContract } from '../languages/ligo';
 import { parseAikenContract } from '../languages/aiken';
 import { parseLeoContract } from '../languages/leo';
@@ -43,6 +44,7 @@ export type ContractLanguage =
   | 'scilla'
   | 'pact'
   | 'scrypto'
+  | 'soroban'
   | 'ligo'
   | 'aiken'
   | 'leo';
@@ -78,6 +80,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'pact';
   } else if (extension === '.scrypto' || extension === '.rs') {
       return 'scrypto';
+  } else if (extension === '.soroban') {
+      return 'soroban';
   } else if (extension === '.ligo' || extension === '.mligo' || extension === '.religo' || extension === '.jsligo') {
       return 'ligo';
   } else if (extension === '.ak' || extension === '.aiken') {
@@ -129,6 +133,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'scrypto':
             graph = parseScryptoContract(code);
+            break;
+        case 'soroban':
+            graph = parseSorobanContract(code);
             break;
         case 'scilla':
             graph = parseScillaContract(code);
@@ -263,6 +270,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'clar':
         case 'ink':
         case 'scrypto':
+        case 'soroban':
         case 'scilla':
         case 'pact':
         case 'ligo':

--- a/test/sorobanParser.test.ts
+++ b/test/sorobanParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseSorobanContract } from '../src/languages/soroban';
+
+describe('parseSorobanContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'fn bar() {}',
+      'fn foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseSorobanContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Soroban language adapter
- detect `.soroban` files
- export Soroban adapter and function type filters
- register Soroban language in package.json
- add example and unit test
- document Soroban support

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f3cd49dc83288f9c27513636e13e