### PR TITLE
Add TEAL language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, LIGO, Aiken and Leo.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken and Leo.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -31,6 +31,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Pact (\*.pact)
   - Scrypto (\*.rs, \*.scrypto)
   - Soroban (\*.soroban)
+  - TEAL (\*.teal)
   - LIGO (\*.ligo, \*.mligo, \*.jsligo, \*.religo)
   - Aiken (\*.ak, \*.aiken)
   - Leo (\*.leo)
@@ -118,7 +119,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban and LIGO
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL and LIGO
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/teal/hello.teal
+++ b/examples/teal/hello.teal
@@ -1,0 +1,11 @@
+#pragma version 8
+
+sub bar() {
+  int 1
+  return
+}
+
+sub foo() {
+  bar();
+  return
+}

--- a/package.json
+++ b/package.json
@@ -210,6 +210,15 @@
         "aliases": [
           "Leo"
         ]
+      },
+      {
+        "id": "teal",
+        "extensions": [
+          ".teal"
+        ],
+        "aliases": [
+          "TEAL"
+        ]
       }
     ],
     "commands": [
@@ -250,24 +259,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -13,6 +13,7 @@ import sorobanAdapter from './soroban';
 import ligoAdapter from './ligo';
 import aikenAdapter from './aiken';
 import leoAdapter from './leo';
+import tealAdapter from './teal';
 
 const adapters = [
   ...adaptersFunc,
@@ -27,6 +28,7 @@ const adapters = [
   pactAdapter,
   scryptoAdapter,
   sorobanAdapter,
+  tealAdapter,
   ligoAdapter,
   aikenAdapter,
   leoAdapter
@@ -45,6 +47,7 @@ export {
   pactAdapter,
   scryptoAdapter,
   sorobanAdapter,
+  tealAdapter,
   ligoAdapter,
   aikenAdapter,
   leoAdapter

--- a/src/languages/teal/index.ts
+++ b/src/languages/teal/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseTeal(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:sub)/);
+}
+
+export const tealAdapter: LanguageAdapter = {
+  fileExtensions: ['.teal'],
+  parse(source: string): AST {
+    return parseTeal(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default tealAdapter;
+
+export function parseTealContract(code: string): ContractGraph {
+  const ast = parseTeal(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -18,6 +18,7 @@ import { parseSorobanContract } from '../languages/soroban';
 import { parseLigoContract } from '../languages/ligo';
 import { parseAikenContract } from '../languages/aiken';
 import { parseLeoContract } from '../languages/leo';
+import { parseTealContract } from '../languages/teal';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -47,7 +48,8 @@ export type ContractLanguage =
   | 'soroban'
   | 'ligo'
   | 'aiken'
-  | 'leo';
+  | 'leo'
+  | 'teal';
 
 /**
  * Detects the language based on file extension
@@ -82,6 +84,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'scrypto';
   } else if (extension === '.soroban') {
       return 'soroban';
+  } else if (extension === '.teal') {
+      return 'teal';
   } else if (extension === '.ligo' || extension === '.mligo' || extension === '.religo' || extension === '.jsligo') {
       return 'ligo';
   } else if (extension === '.ak' || extension === '.aiken') {
@@ -139,6 +143,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'scilla':
             graph = parseScillaContract(code);
+            break;
+        case 'teal':
+            graph = parseTealContract(code);
             break;
         case 'pact':
             graph = parsePactContract(code);
@@ -273,6 +280,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'soroban':
         case 'scilla':
         case 'pact':
+        case 'teal':
         case 'ligo':
         case 'aiken':
         case 'leo':

--- a/test/tealParser.test.ts
+++ b/test/tealParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseTealContract } from '../src/languages/teal';
+
+describe('parseTealContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'sub bar() {}',
+      'sub foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseTealContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a TEAL parser using simple parser functions
- register TEAL adapter in language index
- detect `.teal` files and handle them in parser utilities
- include TEAL in menus and contributions
- document TEAL usage and provide sample
- test TEAL parsing logic

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f572a9c48328946f136034d775eb