### PR TITLE
Add Glow language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken and Leo.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken, Leo and Glow.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -35,6 +35,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - LIGO (\*.ligo, \*.mligo, \*.jsligo, \*.religo)
   - Aiken (\*.ak, \*.aiken)
   - Leo (\*.leo)
+  - Glow (\*.glow)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -119,7 +120,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL and LIGO
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken, Leo and Glow
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/glow/hello.glow
+++ b/examples/glow/hello.glow
@@ -1,0 +1,6 @@
+fun bar() {
+}
+
+fun foo() {
+  bar();
+}

--- a/marketplace-description.md
+++ b/marketplace-description.md
@@ -1,1 +1,1 @@
-Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO, Aiken and Leo contracts. Move support requires the move-analyzer tool.
+Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO, Aiken, Leo and Glow contracts. Move support requires the move-analyzer tool.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "onLanguage:soroban",
     "onLanguage:ligo",
     "onLanguage:aiken",
-    "onLanguage:leo"
+    "onLanguage:leo",
+    "onLanguage:glow"
   ],
   "contributes": {
     "languages": [
@@ -219,6 +220,15 @@
         "aliases": [
           "TEAL"
         ]
+      },
+      {
+        "id": "glow",
+        "extensions": [
+          ".glow"
+        ],
+        "aliases": [
+          "Glow"
+        ]
       }
     ],
     "commands": [
@@ -259,24 +269,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow",
           "group": "navigation"
         }
       ]

--- a/src/languages/glow/index.ts
+++ b/src/languages/glow/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseGlow(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:fun|function)/);
+}
+
+export const glowAdapter: LanguageAdapter = {
+  fileExtensions: ['.glow'],
+  parse(source: string): AST {
+    return parseGlow(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default glowAdapter;
+
+export function parseGlowContract(code: string): ContractGraph {
+  const ast = parseGlow(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -14,6 +14,7 @@ import ligoAdapter from './ligo';
 import aikenAdapter from './aiken';
 import leoAdapter from './leo';
 import tealAdapter from './teal';
+import glowAdapter from './glow';
 
 const adapters = [
   ...adaptersFunc,
@@ -31,7 +32,8 @@ const adapters = [
   tealAdapter,
   ligoAdapter,
   aikenAdapter,
-  leoAdapter
+  leoAdapter,
+  glowAdapter
 ];
 
 export default adapters;
@@ -50,5 +52,6 @@ export {
   tealAdapter,
   ligoAdapter,
   aikenAdapter,
-  leoAdapter
+  leoAdapter,
+  glowAdapter
 };

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -19,6 +19,7 @@ import { parseLigoContract } from '../languages/ligo';
 import { parseAikenContract } from '../languages/aiken';
 import { parseLeoContract } from '../languages/leo';
 import { parseTealContract } from '../languages/teal';
+import { parseGlowContract } from '../languages/glow';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -49,7 +50,8 @@ export type ContractLanguage =
   | 'ligo'
   | 'aiken'
   | 'leo'
-  | 'teal';
+  | 'teal'
+  | 'glow';
 
 /**
  * Detects the language based on file extension
@@ -92,6 +94,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'aiken';
   } else if (extension === '.leo') {
       return 'leo';
+  } else if (extension === '.glow') {
+      return 'glow';
   }
 
     // Default to FunC
@@ -158,6 +162,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'leo':
             graph = parseLeoContract(code);
+            break;
+        case 'glow':
+            graph = parseGlowContract(code);
             break;
         case 'func':
         default:
@@ -284,6 +291,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'ligo':
         case 'aiken':
         case 'leo':
+        case 'glow':
             return [
                 { value: 'regular', label: 'Regular' }
             ];

--- a/test/glowParser.test.ts
+++ b/test/glowParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseGlowContract } from '../src/languages/glow';
+
+describe('parseGlowContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'fun bar() {}',
+      'fun foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseGlowContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- parse Glow contracts using `parseSimpleFunctions`
- register Glow adapter and language id
- update parser utils for Glow language detection and filtering
- provide example and unit tests
- document Glow in README and marketplace description

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f7c901d88328b1252afa7add97e5