### PR TITLE
Add Sophia language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken, Leo, Glow and Bamboo.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken, Leo, Glow, Bamboo and Sophia.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -37,6 +37,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Leo (\*.leo)
   - Glow (\*.glow)
   - Bamboo (\*.bamboo)
+  - Sophia (\*.aes)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -121,7 +122,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken, Leo, Glow and Bamboo
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken, Leo, Glow, Bamboo and Sophia
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/sophia/hello.aes
+++ b/examples/sophia/hello.aes
@@ -1,0 +1,6 @@
+entrypoint bar() {
+}
+
+entrypoint foo() {
+  bar();
+}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "onLanguage:aiken",
     "onLanguage:leo",
     "onLanguage:glow",
-    "onLanguage:bamboo"
+    "onLanguage:bamboo",
+    "onLanguage:sophia"
   ],
   "contributes": {
     "languages": [
@@ -239,6 +240,15 @@
         "aliases": [
           "Bamboo"
         ]
+      },
+      {
+        "id": "sophia",
+        "extensions": [
+          ".aes"
+        ],
+        "aliases": [
+          "Sophia"
+        ]
       }
     ],
     "commands": [
@@ -279,24 +289,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -16,6 +16,7 @@ import leoAdapter from './leo';
 import tealAdapter from './teal';
 import glowAdapter from './glow';
 import bambooAdapter from './bamboo';
+import sophiaAdapter from './sophia';
 
 const adapters = [
   ...adaptersFunc,
@@ -35,7 +36,8 @@ const adapters = [
   aikenAdapter,
   leoAdapter,
   glowAdapter,
-  bambooAdapter
+  bambooAdapter,
+  sophiaAdapter
 ];
 
 export default adapters;
@@ -56,5 +58,6 @@ export {
   aikenAdapter,
   leoAdapter,
   glowAdapter,
-  bambooAdapter
+  bambooAdapter,
+  sophiaAdapter
 };

--- a/src/languages/sophia/index.ts
+++ b/src/languages/sophia/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseSophia(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:entrypoint|function)/);
+}
+
+export const sophiaAdapter: LanguageAdapter = {
+  fileExtensions: ['.aes'],
+  parse(source: string): AST {
+    return parseSophia(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default sophiaAdapter;
+
+export function parseSophiaContract(code: string): ContractGraph {
+  const ast = parseSophia(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -21,6 +21,7 @@ import { parseLeoContract } from '../languages/leo';
 import { parseTealContract } from '../languages/teal';
 import { parseGlowContract } from '../languages/glow';
 import { parseBambooContract } from '../languages/bamboo';
+import { parseSophiaContract } from '../languages/sophia';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -53,7 +54,8 @@ export type ContractLanguage =
   | 'leo'
   | 'teal'
   | 'glow'
-  | 'bamboo';
+  | 'bamboo'
+  | 'sophia';
 
 /**
  * Detects the language based on file extension
@@ -100,6 +102,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'glow';
   } else if (extension === '.bamboo') {
       return 'bamboo';
+  } else if (extension === '.aes') {
+      return 'sophia';
   }
 
     // Default to FunC
@@ -169,6 +173,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'glow':
             graph = parseGlowContract(code);
+            break;
+        case 'sophia':
+            graph = parseSophiaContract(code);
             break;
         case 'bamboo':
             graph = parseBambooContract(code);
@@ -300,6 +307,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'leo':
         case 'glow':
         case 'bamboo':
+        case 'sophia':
             return [
                 { value: 'regular', label: 'Regular' }
             ];

--- a/test/sophiaParser.test.ts
+++ b/test/sophiaParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseSophiaContract } from '../src/languages/sophia';
+
+describe('parseSophiaContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'entrypoint bar() {}',
+      'entrypoint foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseSophiaContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement Sophia parser and register adapter
- update parser utilities and language index
- extend VSCode contributions for `.aes`
- document Sophia support
- add Sophia example and tests

## Testing
- `npm ci` *(fails: Download failed)*

------
https://chatgpt.com/codex/tasks/task_e_68441c4e0ae483288d39d2b84f0842d8