### PR TITLE
Add Flint language parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken, Leo, Glow, Bamboo and Sophia.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken, Leo, Glow, Bamboo, Sophia and Flint.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -38,6 +38,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Glow (\*.glow)
   - Bamboo (\*.bamboo)
   - Sophia (\*.aes)
+  - Flint (\*.flint)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -122,7 +123,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken, Leo, Glow, Bamboo and Sophia
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Aiken, Leo, Glow, Bamboo, Sophia and Flint
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/flint/hello.flint
+++ b/examples/flint/hello.flint
@@ -1,0 +1,5 @@
+fun bar() {}
+
+fun foo() {
+  bar();
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "onLanguage:leo",
     "onLanguage:glow",
     "onLanguage:bamboo",
-    "onLanguage:sophia"
+    "onLanguage:sophia",
+    "onLanguage:flint"
   ],
   "contributes": {
     "languages": [
@@ -249,6 +250,15 @@
         "aliases": [
           "Sophia"
         ]
+      },
+      {
+        "id": "flint",
+        "extensions": [
+          ".flint"
+        ],
+        "aliases": [
+          "Flint"
+        ]
       }
     ],
     "commands": [
@@ -289,24 +299,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint",
           "group": "navigation"
         }
       ]

--- a/src/languages/flint/index.ts
+++ b/src/languages/flint/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseFlint(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /fun/);
+}
+
+export const flintAdapter: LanguageAdapter = {
+  fileExtensions: ['.flint'],
+  parse(source: string): AST {
+    return parseFlint(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default flintAdapter;
+
+export function parseFlintContract(code: string): ContractGraph {
+  const ast = parseFlint(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -17,6 +17,7 @@ import tealAdapter from './teal';
 import glowAdapter from './glow';
 import bambooAdapter from './bamboo';
 import sophiaAdapter from './sophia';
+import flintAdapter from './flint';
 
 const adapters = [
   ...adaptersFunc,
@@ -37,7 +38,8 @@ const adapters = [
   leoAdapter,
   glowAdapter,
   bambooAdapter,
-  sophiaAdapter
+  sophiaAdapter,
+  flintAdapter
 ];
 
 export default adapters;
@@ -59,5 +61,6 @@ export {
   leoAdapter,
   glowAdapter,
   bambooAdapter,
-  sophiaAdapter
+  sophiaAdapter,
+  flintAdapter
 };

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -22,6 +22,7 @@ import { parseTealContract } from '../languages/teal';
 import { parseGlowContract } from '../languages/glow';
 import { parseBambooContract } from '../languages/bamboo';
 import { parseSophiaContract } from '../languages/sophia';
+import { parseFlintContract } from '../languages/flint';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -55,7 +56,8 @@ export type ContractLanguage =
   | 'teal'
   | 'glow'
   | 'bamboo'
-  | 'sophia';
+  | 'sophia'
+  | 'flint';
 
 /**
  * Detects the language based on file extension
@@ -102,6 +104,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'glow';
   } else if (extension === '.bamboo') {
       return 'bamboo';
+  } else if (extension === '.flint') {
+      return 'flint';
   } else if (extension === '.aes') {
       return 'sophia';
   }
@@ -173,6 +177,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'glow':
             graph = parseGlowContract(code);
+            break;
+        case 'flint':
+            graph = parseFlintContract(code);
             break;
         case 'sophia':
             graph = parseSophiaContract(code);
@@ -307,6 +314,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'leo':
         case 'glow':
         case 'bamboo':
+        case 'flint':
         case 'sophia':
             return [
                 { value: 'regular', label: 'Regular' }

--- a/test/flintParser.test.ts
+++ b/test/flintParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseFlintContract } from '../src/languages/flint';
+
+describe('parseFlintContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'fun bar() {}',
+      'fun foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseFlintContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- parse `.flint` files
- wire up flint adapter and detection
- update parser utilities
- register language in package.json
- add flint example and parser test
- document Flint language support

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844200ddc78832898b0f90fbe89c7bf