### PR TITLE
Add Reach language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint and Fe.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe and Reach.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -41,6 +41,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Sophia (\*.aes)
   - Flint (\*.flint)
   - Fe (\*.fe)
+  - Reach (\*.reach)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -125,7 +126,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint and Fe
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe and Reach
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/reach/hello.reach
+++ b/examples/reach/hello.reach
@@ -1,0 +1,5 @@
+function bar() {}
+
+function foo() {
+  bar();
+}

--- a/marketplace-description.md
+++ b/marketplace-description.md
@@ -1,1 +1,1 @@
-Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO, Aiken, Leo, Glow, Flint and Fe contracts. Move support requires the move-analyzer tool.
+Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO, Aiken, Leo, Glow, Flint, Fe and Reach contracts. Move support requires the move-analyzer tool.

--- a/package.json
+++ b/package.json
@@ -270,8 +270,17 @@
         "aliases": [
           "Fe"
         ]
-      }
-      ,{
+      },
+      {
+        "id": "reach",
+        "extensions": [
+          ".reach"
+        ],
+        "aliases": [
+          "Reach"
+        ]
+      },
+      {
         "id": "liquidity",
         "extensions": [
           ".liq"
@@ -319,24 +328,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == liquidity",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == liquidity",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == liquidity",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == liquidity",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .liq",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .liq",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .liq",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .liq",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -20,6 +20,7 @@ import sophiaAdapter from './sophia';
 import flintAdapter from './flint';
 import feAdapter from './fe';
 import liquidityAdapter from './liquidity';
+import reachAdapter from './reach';
 
 const adapters = [
   ...adaptersFunc,
@@ -43,7 +44,8 @@ const adapters = [
   sophiaAdapter,
   flintAdapter,
   feAdapter,
-  liquidityAdapter
+  liquidityAdapter,
+  reachAdapter
 ];
 
 export default adapters;
@@ -68,5 +70,6 @@ export {
   sophiaAdapter,
   flintAdapter,
   feAdapter,
-  liquidityAdapter
+  liquidityAdapter,
+  reachAdapter
 };

--- a/src/languages/reach/index.ts
+++ b/src/languages/reach/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseReach(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:function|fun)/);
+}
+
+export const reachAdapter: LanguageAdapter = {
+  fileExtensions: ['.reach'],
+  parse(source: string): AST {
+    return parseReach(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default reachAdapter;
+
+export function parseReachContract(code: string): ContractGraph {
+  const ast = parseReach(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -25,6 +25,7 @@ import { parseSophiaContract } from '../languages/sophia';
 import { parseFlintContract } from '../languages/flint';
 import { parseFeContract } from '../languages/fe';
 import { parseLiquidityContract } from '../languages/liquidity';
+import { parseReachContract } from '../languages/reach';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -61,7 +62,8 @@ export type ContractLanguage =
   | 'sophia'
   | 'flint'
   | 'liquidity'
-  | 'fe';
+  | 'fe'
+  | 'reach';
 
 /**
  * Detects the language based on file extension
@@ -112,6 +114,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'fe';
   } else if (extension === '.flint') {
       return 'flint';
+  } else if (extension === '.reach') {
+      return 'reach';
   } else if (extension === '.liq') {
       return 'liquidity';
   } else if (extension === '.aes') {
@@ -191,6 +195,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'flint':
             graph = parseFlintContract(code);
+            break;
+        case 'reach':
+            graph = parseReachContract(code);
             break;
         case 'liquidity':
             graph = parseLiquidityContract(code);
@@ -329,6 +336,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'glow':
         case 'bamboo':
         case 'flint':
+        case 'reach':
         case 'liquidity':
         case 'fe':
         case 'sophia':

--- a/test/reachParser.test.ts
+++ b/test/reachParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseReachContract } from '../src/languages/reach';
+
+describe('parseReachContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'function bar() {}',
+      'function foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseReachContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `parseReach` and adapter using `parseSimpleFunctions`
- enable `.reach` parsing in `parserUtils` and language index
- add examples and tests for Reach
- expand language contributions and docs

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442f977b6c8328a738528c981a6485