### PR TITLE
Add Rell language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe, Reach and Rholang.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe, Reach, Rell and Rholang.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -42,6 +42,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Flint (\*.flint)
   - Fe (\*.fe)
   - Reach (\*.reach)
+  - Rell (\*.rell)
   - Rholang (\*.rho)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
@@ -127,7 +128,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe, Reach and Rholang
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe, Reach, Rell and Rholang
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/rell/hello.rell
+++ b/examples/rell/hello.rell
@@ -1,0 +1,5 @@
+function bar() {}
+
+function foo() {
+  bar();
+}

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "onLanguage:flint",
     "onLanguage:fe",
     "onLanguage:liquidity",
+    "onLanguage:rell",
     "onLanguage:rholang"
   ],
   "contributes": {
@@ -282,6 +283,15 @@
         ]
       },
       {
+        "id": "rell",
+        "extensions": [
+          ".rell"
+        ],
+        "aliases": [
+          "Rell"
+        ]
+      },
+      {
         "id": "liquidity",
         "extensions": [
           ".liq"
@@ -338,24 +348,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == liquidity || resourceLangId == rholang",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == liquidity || resourceLangId == rholang",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .liq || resourceExtname == .rho",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .liq || resourceExtname == .rho",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -21,6 +21,7 @@ import flintAdapter from './flint';
 import feAdapter from './fe';
 import liquidityAdapter from './liquidity';
 import reachAdapter from './reach';
+import rellAdapter from './rell';
 import rholangAdapter from './rholang';
 
 const adapters = [
@@ -47,6 +48,7 @@ const adapters = [
   feAdapter,
   liquidityAdapter,
   reachAdapter,
+  rellAdapter,
   rholangAdapter
 ];
 
@@ -74,5 +76,6 @@ export {
   feAdapter,
   liquidityAdapter,
   reachAdapter,
+  rellAdapter,
   rholangAdapter
 };

--- a/src/languages/rell/index.ts
+++ b/src/languages/rell/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseRell(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:function|fn)/);
+}
+
+export const rellAdapter: LanguageAdapter = {
+  fileExtensions: ['.rell'],
+  parse(source: string): AST {
+    return parseRell(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default rellAdapter;
+
+export function parseRellContract(code: string): ContractGraph {
+  const ast = parseRell(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -26,6 +26,7 @@ import { parseFlintContract } from '../languages/flint';
 import { parseFeContract } from '../languages/fe';
 import { parseLiquidityContract } from '../languages/liquidity';
 import { parseReachContract } from '../languages/reach';
+import { parseRellContract } from '../languages/rell';
 import { parseRholangContract } from '../languages/rholang';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
@@ -65,6 +66,7 @@ export type ContractLanguage =
   | 'liquidity'
   | 'fe'
   | 'reach'
+  | 'rell'
   | 'rholang';
 
 /**
@@ -116,6 +118,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'fe';
   } else if (extension === '.flint') {
       return 'flint';
+  } else if (extension === '.rell') {
+      return 'rell';
   } else if (extension === '.reach') {
       return 'reach';
   } else if (extension === '.rho') {
@@ -202,6 +206,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'reach':
             graph = parseReachContract(code);
+            break;
+        case 'rell':
+            graph = parseRellContract(code);
             break;
         case 'rholang':
             graph = parseRholangContract(code);
@@ -344,6 +351,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'bamboo':
         case 'flint':
         case 'reach':
+        case 'rell':
         case 'liquidity':
         case 'fe':
         case 'rholang':

--- a/test/rellParser.test.ts
+++ b/test/rellParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseRellContract } from '../src/languages/rell';
+
+describe('parseRellContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'function bar() {}',
+      'function foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseRellContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- parse `.rell` contracts with new adapter
- support `.rell` detection and menus
- document Rell usage
- add Rell example and parser tests

## Testing
- `npm test` *(fails: nyc not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_684453a43cc08328ae0d71168eced0dd