### PR TITLE
Add Marlowe language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe, Reach, Rell and Rholang.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe, Reach, Rell and Rholang.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -31,6 +31,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Pact (\*.pact)
   - Scrypto (\*.rs, \*.scrypto)
   - Soroban (\*.soroban)
+  - Marlowe (\*.marlowe)
   - TEAL (\*.teal)
   - LIGO (\*.ligo, \*.mligo, \*.jsligo, \*.religo)
   - Liquidity (\*.liq)
@@ -128,7 +129,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe, Reach, Rell and Rholang
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe, Reach, Rell and Rholang
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/marlowe/hello.marlowe
+++ b/examples/marlowe/hello.marlowe
@@ -1,0 +1,5 @@
+contract Bar() {}
+
+contract Foo() {
+  when Notify -> Bar();
+}

--- a/marketplace-description.md
+++ b/marketplace-description.md
@@ -1,1 +1,1 @@
-Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, LIGO, Aiken, Leo, Glow, Flint, Fe and Reach contracts. Move support requires the move-analyzer tool.
+Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Marlowe, LIGO, Aiken, Leo, Glow, Flint, Fe and Reach contracts. Move support requires the move-analyzer tool.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "onLanguage:pact",
     "onLanguage:scrypto",
     "onLanguage:soroban",
+    "onLanguage:marlowe",
     "onLanguage:ligo",
     "onLanguage:aiken",
     "onLanguage:leo",
@@ -185,6 +186,15 @@
         ],
         "aliases": [
           "Soroban"
+        ]
+      },
+      {
+        "id": "marlowe",
+        "extensions": [
+          ".marlowe"
+        ],
+        "aliases": [
+          "Marlowe"
         ]
       },
       {
@@ -348,24 +358,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -23,6 +23,7 @@ import liquidityAdapter from './liquidity';
 import reachAdapter from './reach';
 import rellAdapter from './rell';
 import rholangAdapter from './rholang';
+import marloweAdapter from './marlowe';
 
 const adapters = [
   ...adaptersFunc,
@@ -49,7 +50,8 @@ const adapters = [
   liquidityAdapter,
   reachAdapter,
   rellAdapter,
-  rholangAdapter
+  rholangAdapter,
+  marloweAdapter
 ];
 
 export default adapters;
@@ -77,5 +79,6 @@ export {
   liquidityAdapter,
   reachAdapter,
   rellAdapter,
-  rholangAdapter
+  rholangAdapter,
+  marloweAdapter
 };

--- a/src/languages/marlowe/index.ts
+++ b/src/languages/marlowe/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseMarlowe(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:contract|when)/);
+}
+
+export const marloweAdapter: LanguageAdapter = {
+  fileExtensions: ['.marlowe'],
+  parse(source: string): AST {
+    return parseMarlowe(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default marloweAdapter;
+
+export function parseMarloweContract(code: string): ContractGraph {
+  const ast = parseMarlowe(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -28,6 +28,7 @@ import { parseLiquidityContract } from '../languages/liquidity';
 import { parseReachContract } from '../languages/reach';
 import { parseRellContract } from '../languages/rell';
 import { parseRholangContract } from '../languages/rholang';
+import { parseMarloweContract } from '../languages/marlowe';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';
@@ -67,7 +68,8 @@ export type ContractLanguage =
   | 'fe'
   | 'reach'
   | 'rell'
-  | 'rholang';
+  | 'rholang'
+  | 'marlowe';
 
 /**
  * Detects the language based on file extension
@@ -128,6 +130,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'liquidity';
   } else if (extension === '.aes') {
       return 'sophia';
+  } else if (extension === '.marlowe') {
+      return 'marlowe';
   }
 
     // Default to FunC
@@ -221,6 +225,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'bamboo':
             graph = parseBambooContract(code);
+            break;
+        case 'marlowe':
+            graph = parseMarloweContract(code);
             break;
         case 'func':
         default:
@@ -356,6 +363,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'fe':
         case 'rholang':
         case 'sophia':
+        case 'marlowe':
             return [
                 { value: 'regular', label: 'Regular' }
             ];

--- a/test/marloweParser.test.ts
+++ b/test/marloweParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseMarloweContract } from '../src/languages/marlowe';
+
+describe('parseMarloweContract', () => {
+  it('parses contracts and edges', () => {
+    const code = [
+      'contract Bar() {}',
+      'contract Foo() {',
+      '  when Notify -> Bar();',
+      '}'
+    ].join('\n');
+    const graph = parseMarloweContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['Bar', 'Foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'Foo', to: 'Bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- parse `contract` or `when` constructs in Marlowe files
- register `.marlowe` language support and detection
- update parser utilities and filters
- document Marlowe support
- add example and tests

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445943c5688328a19f4225372ebac8