### PR TITLE
Add Huff language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe, Reach, Rell and Rholang.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Huff, Bamboo, Sophia, Flint, Fe, Reach, Rell and Rholang.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -38,6 +38,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Aiken (\*.ak, \*.aiken)
   - Leo (\*.leo)
   - Glow (\*.glow)
+  - Huff (\*.huff)
   - Bamboo (\*.bamboo)
   - Sophia (\*.aes)
   - Flint (\*.flint)
@@ -73,7 +74,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 ## Usage
 
-1. Open a contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact, \*.ligo, \*\*.leo, \*.bamboo or \*.ak)
+1. Open a contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact, \*.ligo, \*\*.leo, \*.glow, \*.huff, \*.bamboo or \*.ak)
    Note: Move contracts are parsed via `move-analyzer`.
 2. You can visualize a contract in multiple ways:
    - Press F1 or Ctrl+Shift+P to open the command palette and type "TON Graph: Visualize Contract"
@@ -85,7 +86,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
 You can also visualize an entire contract including all imports:
 
-1. Open a main contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact, \*.ligo, \*\*.leo, \*.bamboo or \*.ak)
+1. Open a main contract file (\*.fc, \*.func, \*.tact, \*.tolk, \*.move, \*.cairo, \*.plutus, \*.cdc, \*.tz, \*.clar, \*.ink, \*.scilla, \*.pact, \*.ligo, \*\*.leo, \*.glow, \*.huff, \*.bamboo or \*.ak)
 2. Visualize the project in one of these ways:
    - Press F1 or Ctrl+Shift+P and type "TON Graph: Visualize Contract with Imports"
    - Right-click on contract code in the editor → TON Graph: Visualize Contract with Imports
@@ -129,7 +130,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Bamboo, Sophia, Flint, Fe, Reach, Rell and Rholang
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Huff, Bamboo, Sophia, Flint, Fe, Reach, Rell and Rholang
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/huff/simple.huff
+++ b/examples/huff/simple.huff
@@ -1,0 +1,7 @@
+#define macro BAR() = takes(0) returns(0) {
+    0x00
+}
+
+#define macro FOO() = takes(0) returns(0) {
+    BAR()
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "onLanguage:aiken",
     "onLanguage:leo",
     "onLanguage:glow",
+    "onLanguage:huff",
     "onLanguage:bamboo",
     "onLanguage:sophia",
     "onLanguage:flint",
@@ -248,6 +249,15 @@
         ]
       },
       {
+        "id": "huff",
+        "extensions": [
+          ".huff"
+        ],
+        "aliases": [
+          "Huff"
+        ]
+      },
+      {
         "id": "bamboo",
         "extensions": [
           ".bamboo"
@@ -358,24 +368,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == huff || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == huff || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .huff || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .huff || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho",
           "group": "navigation"
         }
       ]

--- a/src/languages/huff/index.ts
+++ b/src/languages/huff/index.ts
@@ -1,0 +1,29 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { SimpleAST, buildSimpleEdges, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseHuff(source: string): SimpleAST {
+  const regex = /#define\s+macro\s+([A-Za-z_][\w]*)\s*\([^)]*\)[^{]*\{([\s\S]*?)\}/g;
+  const functions: { name: string; body: string }[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(source)) !== null) {
+    functions.push({ name: match[1], body: match[2] });
+  }
+  return { functions };
+}
+
+export const huffAdapter: LanguageAdapter = {
+  fileExtensions: ['.huff'],
+  parse(source: string): AST {
+    return parseHuff(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default huffAdapter;
+
+export function parseHuffContract(code: string): ContractGraph {
+  const ast = parseHuff(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -15,6 +15,7 @@ import aikenAdapter from './aiken';
 import leoAdapter from './leo';
 import tealAdapter from './teal';
 import glowAdapter from './glow';
+import huffAdapter from './huff';
 import bambooAdapter from './bamboo';
 import sophiaAdapter from './sophia';
 import flintAdapter from './flint';
@@ -43,6 +44,7 @@ const adapters = [
   aikenAdapter,
   leoAdapter,
   glowAdapter,
+  huffAdapter,
   bambooAdapter,
   sophiaAdapter,
   flintAdapter,
@@ -72,6 +74,7 @@ export {
   aikenAdapter,
   leoAdapter,
   glowAdapter,
+  huffAdapter,
   bambooAdapter,
   sophiaAdapter,
   flintAdapter,

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -20,6 +20,7 @@ import { parseAikenContract } from '../languages/aiken';
 import { parseLeoContract } from '../languages/leo';
 import { parseTealContract } from '../languages/teal';
 import { parseGlowContract } from '../languages/glow';
+import { parseHuffContract } from '../languages/huff';
 import { parseBambooContract } from '../languages/bamboo';
 import { parseSophiaContract } from '../languages/sophia';
 import { parseFlintContract } from '../languages/flint';
@@ -61,6 +62,7 @@ export type ContractLanguage =
   | 'leo'
   | 'teal'
   | 'glow'
+  | 'huff'
   | 'bamboo'
   | 'sophia'
   | 'flint'
@@ -114,6 +116,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'leo';
   } else if (extension === '.glow') {
       return 'glow';
+  } else if (extension === '.huff') {
+      return 'huff';
   } else if (extension === '.bamboo') {
       return 'bamboo';
   } else if (extension === '.fe') {
@@ -201,6 +205,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'glow':
             graph = parseGlowContract(code);
+            break;
+        case 'huff':
+            graph = parseHuffContract(code);
             break;
         case 'fe':
             graph = parseFeContract(code);
@@ -355,6 +362,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'aiken':
         case 'leo':
         case 'glow':
+        case 'huff':
         case 'bamboo':
         case 'flint':
         case 'reach':

--- a/test/huffParser.test.ts
+++ b/test/huffParser.test.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseHuffContract } from '../src/languages/huff';
+
+describe('parseHuffContract', () => {
+  it('parses macros and edges', () => {
+    const code = [
+      '#define macro BAR() = takes(0) returns(0) {',
+      '  0x00',
+      '}',
+      '',
+      '#define macro FOO() = takes(0) returns(0) {',
+      '  BAR()',
+      '}',
+    ].join('\n');
+    const graph = parseHuffContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['BAR', 'FOO']);
+    expect(graph.edges).to.deep.equal([{ from: 'FOO', to: 'BAR', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- parse Huff macro definitions
- register Huff in language adapters and detection
- enable Huff filters in parser utils
- update VS Code contributions and README docs
- provide example contract and unit test

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445cb65e908328bd900ee55ad1697a