### PR TITLE
Add Simplicity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Huff, Bamboo, Sophia, Flint, Fe, Reach, Rell, Rholang and Yul.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Huff, Bamboo, Sophia, Flint, Fe, Reach, Rell, Rholang, Simplicity and Yul.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -46,6 +46,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Reach (\*.reach)
   - Rell (\*.rell)
   - Rholang (\*.rho)
+  - Simplicity (\*.simp)
   - Yul (\*.yul)
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
@@ -131,7 +132,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Huff, Bamboo, Sophia, Flint, Fe, Reach, Rell, Rholang and Yul
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Huff, Bamboo, Sophia, Flint, Fe, Reach, Rell, Rholang, Simplicity and Yul
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/simplicity/hello.simp
+++ b/examples/simplicity/hello.simp
@@ -1,0 +1,5 @@
+fun bar() {}
+
+fun foo() {
+  bar()
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "onLanguage:sophia",
     "onLanguage:flint",
     "onLanguage:fe",
+    "onLanguage:simplicity",
     "onLanguage:liquidity",
     "onLanguage:rell",
     "onLanguage:rholang"
@@ -295,6 +296,15 @@
         ]
       },
       {
+        "id": "simplicity",
+        "extensions": [
+          ".simp"
+        ],
+        "aliases": [
+          "Simplicity"
+        ]
+      },
+      {
         "id": "reach",
         "extensions": [
           ".reach"
@@ -378,24 +388,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == huff || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang || resourceLangId == yul",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == huff || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == simplicity || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang || resourceLangId == yul",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == huff || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang || resourceLangId == yul",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == huff || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == simplicity || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang || resourceLangId == yul",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .huff || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho || resourceExtname == .yul",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .huff || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .simp || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho || resourceExtname == .yul",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .huff || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho || resourceExtname == .yul",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .huff || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .simp || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho || resourceExtname == .yul",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -20,6 +20,7 @@ import bambooAdapter from './bamboo';
 import sophiaAdapter from './sophia';
 import flintAdapter from './flint';
 import feAdapter from './fe';
+import simplicityAdapter from './simplicity';
 import liquidityAdapter from './liquidity';
 import reachAdapter from './reach';
 import rellAdapter from './rell';
@@ -50,6 +51,7 @@ const adapters = [
   sophiaAdapter,
   flintAdapter,
   feAdapter,
+  simplicityAdapter,
   liquidityAdapter,
   reachAdapter,
   rellAdapter,
@@ -81,6 +83,7 @@ export {
   sophiaAdapter,
   flintAdapter,
   feAdapter,
+  simplicityAdapter,
   liquidityAdapter,
   reachAdapter,
   rellAdapter,

--- a/src/languages/simplicity/index.ts
+++ b/src/languages/simplicity/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseSimplicity(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:fun)/);
+}
+
+export const simplicityAdapter: LanguageAdapter = {
+  fileExtensions: ['.simp'],
+  parse(source: string): AST {
+    return parseSimplicity(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default simplicityAdapter;
+
+export function parseSimplicityContract(code: string): ContractGraph {
+  const ast = parseSimplicity(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -25,6 +25,7 @@ import { parseBambooContract } from '../languages/bamboo';
 import { parseSophiaContract } from '../languages/sophia';
 import { parseFlintContract } from '../languages/flint';
 import { parseFeContract } from '../languages/fe';
+import { parseSimplicityContract } from '../languages/simplicity';
 import { parseLiquidityContract } from '../languages/liquidity';
 import { parseReachContract } from '../languages/reach';
 import { parseRellContract } from '../languages/rell';
@@ -69,6 +70,7 @@ export type ContractLanguage =
   | 'flint'
   | 'liquidity'
   | 'fe'
+  | 'simplicity'
   | 'reach'
   | 'rell'
   | 'rholang'
@@ -124,6 +126,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'bamboo';
   } else if (extension === '.fe') {
       return 'fe';
+  } else if (extension === '.simp') {
+      return 'simplicity';
   } else if (extension === '.flint') {
       return 'flint';
   } else if (extension === '.rell') {
@@ -215,6 +219,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'fe':
             graph = parseFeContract(code);
+            break;
+        case 'simplicity':
+            graph = parseSimplicityContract(code);
             break;
         case 'flint':
             graph = parseFlintContract(code);
@@ -376,6 +383,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'rell':
         case 'liquidity':
         case 'fe':
+        case 'simplicity':
         case 'rholang':
         case 'sophia':
         case 'marlowe':

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -112,6 +112,7 @@ describe('Parser', () => {
         expect(detectLanguage('a.tolk')).to.equal('tolk');
         expect(detectLanguage('a.fc')).to.equal('func');
         expect(detectLanguage('Move.toml')).to.equal('move');
+        expect(detectLanguage('a.simp')).to.equal('simplicity');
     });
 
     it('provides function type filters per language', () => {

--- a/test/simplicityParser.test.ts
+++ b/test/simplicityParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseSimplicityContract } from '../src/languages/simplicity';
+
+describe('parseSimplicityContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'fun bar() {}',
+      'fun foo() {',
+      '  bar()',
+      '}'
+    ].join('\n');
+    const graph = parseSimplicityContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- support `.simp` Simplicity contracts
- add Simplicity adapter and update language index
- detect Simplicity in parser utils and tests
- include Simplicity in activation events and menus
- document Simplicity and provide example

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684464469b0883288f067041cd8ebedb