### PR TITLE
Add Noir language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![codecov](https://codecov.io/gh/PositiveSecurity/ton-graph/branch/work/graph/badge.svg)](https://codecov.io/gh/PositiveSecurity/ton-graph)
 [![move](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml/badge.svg)](https://github.com/PositiveSecurity/ton-graph/actions/workflows/move.yml)
 
-A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Huff, Bamboo, Sophia, Flint, Fe, Reach, Rell, Rholang, Simplicity and Yul.
+A Visual Studio Code extension for visualizing function call graphs in smart contracts written in FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Huff, Bamboo, Sophia, Flint, Fe, Noir, Reach, Rell, Rholang, Simplicity and Yul.
 
 Developed by [PositiveWeb3](https://www.positive.com) security researchers.
 
@@ -43,6 +43,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Sophia (\*.aes)
   - Flint (\*.flint)
   - Fe (\*.fe)
+  - Noir (\*.nr, \*.noir)
   - Reach (\*.reach)
   - Rell (\*.rell)
   - Rholang (\*.rho)
@@ -132,7 +133,7 @@ The extension analyzes your contract code to:
 4. Generate a visual representation using [Mermaid](https://mermaid.js.org/) diagrams
 5. Group related functions into clusters for better readability
 6. Multiple contracts support (for Tact)
-7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Huff, Bamboo, Sophia, Flint, Fe, Reach, Rell, Rholang, Simplicity and Yul
+7. Language adapters parse FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Soroban, Marlowe, TEAL, LIGO, Liquidity, Aiken, Leo, Glow, Huff, Bamboo, Sophia, Flint, Fe, Noir, Reach, Rell, Rholang, Simplicity and Yul
 
 <a href="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" target="_blank">
   <img src="https://raw.githubusercontent.com/PositiveSecurity/ton-graph/main/screenshots/scr04.jpg" width="400" alt="Multiple contracts support">

--- a/examples/noir/hello.nr
+++ b/examples/noir/hello.nr
@@ -1,0 +1,5 @@
+fn bar() {}
+
+fn foo() {
+  bar();
+}

--- a/marketplace-description.md
+++ b/marketplace-description.md
@@ -1,1 +1,1 @@
-Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Marlowe, LIGO, Aiken, Leo, Glow, Flint, Fe, Reach and Yul contracts. Move support requires the move-analyzer tool.
+Visualize function call graphs for FunC, Tact, Tolk, Move, Cairo, Plutus, Cadence, Michelson, Clarity, Ink, Scilla, Pact, Scrypto, Marlowe, LIGO, Aiken, Leo, Glow, Flint, Fe, Noir, Reach and Yul contracts. Move support requires the move-analyzer tool.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "onLanguage:sophia",
     "onLanguage:flint",
     "onLanguage:fe",
+    "onLanguage:noir",
     "onLanguage:simplicity",
     "onLanguage:liquidity",
     "onLanguage:rell",
@@ -296,6 +297,16 @@
         ]
       },
       {
+        "id": "noir",
+        "extensions": [
+          ".nr",
+          ".noir"
+        ],
+        "aliases": [
+          "Noir"
+        ]
+      },
+      {
         "id": "simplicity",
         "extensions": [
           ".simp"
@@ -388,24 +399,24 @@
       "editor/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == huff || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == simplicity || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang || resourceLangId == yul",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == huff || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == noir || resourceLangId == simplicity || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang || resourceLangId == yul",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == huff || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == simplicity || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang || resourceLangId == yul",
+          "when": "resourceLangId == func || resourceLangId == tact || resourceLangId == tolk || resourceLangId == move || resourceLangId == cairo || resourceLangId == plutus || resourceLangId == cadence || resourceLangId == michelson || resourceLangId == clar || resourceLangId == ink || resourceLangId == scilla || resourceLangId == pact || resourceLangId == scrypto || resourceLangId == soroban || resourceLangId == marlowe ||  resourceLangId == teal || resourceLangId == ligo || resourceLangId == aiken || resourceLangId == leo || resourceLangId == glow || resourceLangId == huff || resourceLangId == bamboo || resourceLangId == sophia || resourceLangId == flint || resourceLangId == fe || resourceLangId == noir || resourceLangId == simplicity || resourceLangId == reach || resourceLangId == rell || resourceLangId == liquidity || resourceLangId == rholang || resourceLangId == yul",
           "group": "navigation"
         }
       ],
       "explorer/context": [
         {
           "command": "ton-graph.visualize",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .huff || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .simp || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho || resourceExtname == .yul",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .huff || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .nr || resourceExtname == .noir || resourceExtname == .simp || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho || resourceExtname == .yul",
           "group": "navigation"
         },
         {
           "command": "ton-graph.visualizeProject",
-          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .huff || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .simp || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho || resourceExtname == .yul",
+          "when": "resourceExtname == .fc || resourceExtname == .func || resourceExtname == .tact || resourceExtname == .tolk || resourceExtname == .move || resourceExtname == .cairo || resourceExtname == .plutus || resourceExtname == .cdc || resourceExtname == .tz || resourceExtname == .clar || resourceExtname == .ink || resourceExtname == .scilla || resourceExtname == .pact || resourceExtname == .rs || resourceExtname == .scrypto || resourceExtname == .soroban || resourceExtname == .marlowe ||  resourceExtname == .teal || resourceExtname == .ligo || resourceExtname == .mligo || resourceExtname == .religo || resourceExtname == .jsligo || resourceExtname == .ak || resourceExtname == .aiken || resourceExtname == .leo || resourceExtname == .glow || resourceExtname == .huff || resourceExtname == .bamboo || resourceExtname == .aes || resourceExtname == .flint || resourceExtname == .fe || resourceExtname == .nr || resourceExtname == .noir || resourceExtname == .simp || resourceExtname == .reach || resourceExtname == .rell || resourceExtname == .liq || resourceExtname == .rho || resourceExtname == .yul",
           "group": "navigation"
         }
       ]

--- a/src/languages/index.ts
+++ b/src/languages/index.ts
@@ -20,6 +20,7 @@ import bambooAdapter from './bamboo';
 import sophiaAdapter from './sophia';
 import flintAdapter from './flint';
 import feAdapter from './fe';
+import noirAdapter from './noir';
 import simplicityAdapter from './simplicity';
 import liquidityAdapter from './liquidity';
 import reachAdapter from './reach';
@@ -51,6 +52,7 @@ const adapters = [
   sophiaAdapter,
   flintAdapter,
   feAdapter,
+  noirAdapter,
   simplicityAdapter,
   liquidityAdapter,
   reachAdapter,
@@ -83,6 +85,7 @@ export {
   sophiaAdapter,
   flintAdapter,
   feAdapter,
+  noirAdapter,
   simplicityAdapter,
   liquidityAdapter,
   reachAdapter,

--- a/src/languages/noir/index.ts
+++ b/src/languages/noir/index.ts
@@ -1,0 +1,23 @@
+import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
+import { ContractGraph } from '../../types/graph';
+
+export function parseNoir(source: string): SimpleAST {
+  return parseSimpleFunctions(source, /(?:fn)/);
+}
+
+export const noirAdapter: LanguageAdapter = {
+  fileExtensions: ['.nr', '.noir'],
+  parse(source: string): AST {
+    return parseNoir(source) as unknown as AST;
+  },
+  buildCallGraph(ast: AST): Edge[] {
+    return buildSimpleEdges(ast as unknown as SimpleAST);
+  }
+};
+export default noirAdapter;
+
+export function parseNoirContract(code: string): ContractGraph {
+  const ast = parseNoir(code);
+  return simpleAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -25,6 +25,7 @@ import { parseBambooContract } from '../languages/bamboo';
 import { parseSophiaContract } from '../languages/sophia';
 import { parseFlintContract } from '../languages/flint';
 import { parseFeContract } from '../languages/fe';
+import { parseNoirContract } from '../languages/noir';
 import { parseSimplicityContract } from '../languages/simplicity';
 import { parseLiquidityContract } from '../languages/liquidity';
 import { parseReachContract } from '../languages/reach';
@@ -70,6 +71,7 @@ export type ContractLanguage =
   | 'flint'
   | 'liquidity'
   | 'fe'
+  | 'noir'
   | 'simplicity'
   | 'reach'
   | 'rell'
@@ -126,6 +128,8 @@ export function detectLanguage(filePath: string): ContractLanguage {
       return 'bamboo';
   } else if (extension === '.fe') {
       return 'fe';
+  } else if (extension === '.nr' || extension === '.noir') {
+      return 'noir';
   } else if (extension === '.simp') {
       return 'simplicity';
   } else if (extension === '.flint') {
@@ -219,6 +223,9 @@ export async function parseContractByLanguage(code: string, language: ContractLa
             break;
         case 'fe':
             graph = parseFeContract(code);
+            break;
+        case 'noir':
+            graph = parseNoirContract(code);
             break;
         case 'simplicity':
             graph = parseSimplicityContract(code);
@@ -383,6 +390,7 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'rell':
         case 'liquidity':
         case 'fe':
+        case 'noir':
         case 'simplicity':
         case 'rholang':
         case 'sophia':

--- a/test/noirParser.test.ts
+++ b/test/noirParser.test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) } });
+import { parseNoirContract } from '../src/languages/noir';
+
+describe('parseNoirContract', () => {
+  it('parses functions and edges', () => {
+    const code = [
+      'fn bar() {}',
+      'fn foo() {',
+      '  bar();',
+      '}'
+    ].join('\n');
+    const graph = parseNoirContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- add Noir language adapter and parser
- register Noir file extensions in parser utils
- update function filters and activation rules
- document Noir in README and marketplace description
- add Noir example and parser tests

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684467bff75883288e1cdb09236df654