### PR TITLE
Add Noir parser with tree-sitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -489,6 +489,7 @@
     "mermaid": "^11.6.0",
     "moo": "^0.5.2",
     "tree-sitter-move": "github:tzakian/tree-sitter-move",
+    "tree-sitter-noir": "^1.0.1",
     "vscode-languageclient": "^9.0.1",
     "web-tree-sitter": "^0.25.6",
     "winston": "^3.17.0",

--- a/src/languages/noir/index.ts
+++ b/src/languages/noir/index.ts
@@ -1,23 +1,23 @@
 import { AST, Edge, LanguageAdapter } from '../../types/core';
-import { parseSimpleFunctions, buildSimpleEdges, SimpleAST, simpleAstToGraph } from '../simple';
 import { ContractGraph } from '../../types/graph';
+import { parseNoir as parseNoirSource, NoirAST, noirAstToGraph, parseNoirContract as parseNoirContractParser } from '../../parser/noirParser';
 
-export function parseNoir(source: string): SimpleAST {
-  return parseSimpleFunctions(source, /(?:fn)/);
+export function parseNoir(source: string): NoirAST {
+  return parseNoirSource(source).ast;
 }
 
 export const noirAdapter: LanguageAdapter = {
   fileExtensions: ['.nr', '.noir'],
   parse(source: string): AST {
-    return parseNoir(source) as unknown as AST;
+    return parseNoirSource(source).ast as unknown as AST;
   },
   buildCallGraph(ast: AST): Edge[] {
-    return buildSimpleEdges(ast as unknown as SimpleAST);
+    const graph = noirAstToGraph(ast as unknown as NoirAST);
+    return graph.edges;
   }
 };
 export default noirAdapter;
 
 export function parseNoirContract(code: string): ContractGraph {
-  const ast = parseNoir(code);
-  return simpleAstToGraph(ast);
+  return parseNoirContractParser(code);
 }

--- a/src/parser/noirParser.ts
+++ b/src/parser/noirParser.ts
@@ -1,0 +1,105 @@
+import Parser from 'tree-sitter';
+import Noir from 'tree-sitter-noir';
+import { ContractGraph, ContractNode } from '../types/graph';
+import { GraphNodeKind } from '../types/graphNodeKind';
+
+export interface NoirFunction {
+  name: string;
+  body?: Parser.SyntaxNode;
+}
+
+export interface NoirAST {
+  functions: NoirFunction[];
+}
+
+let parser: Parser | null = null;
+function getParser(): Parser {
+  if (!parser) {
+    parser = new Parser();
+    parser.setLanguage(Noir as any);
+  }
+  return parser;
+}
+
+export function walk(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode[] {
+  const res: Parser.SyntaxNode[] = [];
+  const stack = [node];
+  while (stack.length) {
+    const n = stack.pop();
+    if (!n) continue;
+    if (n.type === type) res.push(n);
+    stack.push(...n.namedChildren);
+  }
+  return res;
+}
+
+export function parseNoir(code: string): { ast: NoirAST; tree: Parser.Tree } {
+  const p = getParser();
+  let tree: Parser.Tree;
+  try {
+    tree = p.parse(code);
+  } catch {
+    tree = p.parse('');
+  }
+  const functions: NoirFunction[] = [];
+  const fnNodes = walk(tree.rootNode, 'function_definition');
+  for (const fn of fnNodes) {
+    const idNode = fn.namedChildren.find(c => c.type === 'identifier');
+    const bodyNode = fn.namedChildren.find(c => c.type === 'body');
+    if (idNode) {
+      functions.push({ name: idNode.text, body: bodyNode });
+    }
+  }
+  return { ast: { functions }, tree };
+}
+
+export function noirAstToGraph(ast: NoirAST): ContractGraph {
+  const graph: ContractGraph = { nodes: [], edges: [] };
+  const funcMap = new Map<string, ContractNode>();
+  const edgeSet = new Set<string>();
+
+  for (const f of ast.functions) {
+    const node: ContractNode = {
+      id: f.name,
+      label: `${f.name}()`,
+      type: GraphNodeKind.Function,
+      contractName: 'Contract',
+      parameters: [],
+      functionType: 'regular'
+    };
+    graph.nodes.push(node);
+    funcMap.set(f.name, node);
+  }
+
+  for (const f of ast.functions) {
+    if (!f.body) continue;
+    const from = f.name;
+    const calls = walk(f.body, 'function_call');
+    for (const call of calls) {
+      const idNode = call.namedChildren.find(c => c.type === 'identifier');
+      if (!idNode) continue;
+      const to = idNode.text;
+      const key = `${from}->${to}`;
+      if (!edgeSet.has(key)) {
+        edgeSet.add(key);
+        if (!funcMap.has(to)) {
+          graph.nodes.push({
+            id: to,
+            label: `${to}()`,
+            type: GraphNodeKind.Function,
+            contractName: 'Contract'
+          });
+          funcMap.set(to, graph.nodes[graph.nodes.length - 1]);
+        }
+        graph.edges.push({ from, to, label: '' });
+      }
+    }
+  }
+
+  return graph;
+}
+
+export function parseNoirContract(code: string): ContractGraph {
+  const { ast } = parseNoir(code);
+  return noirAstToGraph(ast);
+}

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -25,7 +25,7 @@ import { parseBambooContract } from '../languages/bamboo';
 import { parseSophiaContract } from '../languages/sophia';
 import { parseFlintContract } from '../languages/flint';
 import { parseFeContract } from '../languages/fe';
-import { parseNoirContract } from '../languages/noir';
+import { parseNoirContract } from './noirParser';
 import { parseSimplicityContract } from '../languages/simplicity';
 import { parseLiquidityContract } from '../languages/liquidity';
 import { parseReachContract } from '../languages/reach';


### PR DESCRIPTION
## Summary
- add tree-sitter-noir dependency
- implement parser/noirParser using tree-sitter
- integrate new parser with language adapter
- update parserUtils import

## Testing
- `npm ci --silent` *(fails: nyc not found when running tests)*

------
https://chatgpt.com/codex/tasks/task_e_684475ef27e483288ac345cd18fb89a3