### PR TITLE
Add tests for Noir examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Rholang (\*.rho)
   - Simplicity (\*.simp)
   - Yul (\*.yul)
+  - Support for Noir is powered by [tree-sitter-noir](https://github.com/noir-lang/tree-sitter-noir). Example contracts are available in `examples/noir`.
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)

--- a/test/noirParser.test.ts
+++ b/test/noirParser.test.ts
@@ -65,4 +65,39 @@ describe('parseNoirContract', () => {
     expect(graph.nodes).to.be.empty;
     expect(graph.edges).to.be.empty;
   });
+
+  it('parses the hello.nr example file', () => {
+    const fs = require('fs');
+    const code = fs.readFileSync('examples/noir/hello.nr', 'utf8');
+    const graph = parseNoirContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.have.members(['bar', 'foo']);
+    expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
+  });
+
+  it('parses the complex.nr example file', () => {
+    const fs = require('fs');
+    const code = fs.readFileSync('examples/noir/complex.nr', 'utf8');
+    const graph = parseNoirContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.include.members([
+      'hash_pair',
+      'merkle_hash',
+      'verify_merkle',
+      'update_proposal',
+      'record_vote',
+      'aggregate_votes',
+      'has_majority',
+      'main'
+    ]);
+    expect(graph.edges).to.deep.equal([
+      { from: 'merkle_hash', to: 'hash_pair', label: '' },
+      { from: 'verify_merkle', to: 'merkle_hash', label: '' },
+      { from: 'record_vote', to: 'verify_merkle', label: '' },
+      { from: 'record_vote', to: 'update_proposal', label: '' },
+      { from: 'main', to: 'record_vote', label: '' },
+      { from: 'main', to: 'aggregate_votes', label: '' },
+      { from: 'main', to: 'has_majority', label: '' }
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- add note about Noir parser in README
- add tests for `hello.nr` and `complex.nr`

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447b4961088328bd47d016e6fdb491