### PR TITLE
Fix regex escaping in buildSimpleEdges

### DIFF
--- a/src/languages/simple.ts
+++ b/src/languages/simple.ts
@@ -23,7 +23,8 @@ export function buildSimpleEdges(ast: SimpleAST): { from: string; to: string }[]
   const edgeSet = new Set<string>();
   const names = ast.functions.map(f => f.name);
   if (names.length === 0) return edges;
-  const callRegex = new RegExp(`\\b(${names.join('|')})\\s*\\(`, 'g');
+  const escapedNames = names.map(n => n.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const callRegex = new RegExp(`\\b(${escapedNames.join('|')})\\s*\\(`, 'g');
   for (const fn of ast.functions) {
     let m: RegExpExecArray | null;
     while ((m = callRegex.exec(fn.body)) !== null) {

--- a/test/buildSimpleEdges.test.ts
+++ b/test/buildSimpleEdges.test.ts
@@ -1,0 +1,15 @@
+import { expect } from 'chai';
+import { buildSimpleEdges, SimpleAST } from '../src/languages/simple';
+
+describe('buildSimpleEdges', () => {
+  it('handles names with special regex characters', () => {
+    const ast: SimpleAST = {
+      functions: [
+        { name: 'foo$bar', body: '' },
+        { name: 'baz', body: 'foo$bar();' }
+      ]
+    };
+    const edges = buildSimpleEdges(ast);
+    expect(edges).to.deep.equal([{ from: 'baz', to: 'foo$bar' }]);
+  });
+});


### PR DESCRIPTION
## Summary
- escape function names used in regex in `buildSimpleEdges`
- add regression test for names with `$`

## Testing
- `npx -y nyc mocha -r ts-node/register test/**/*.test.ts` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_68447d1c34b483288425ac158129e0fe