### PR TITLE
Enhance Noir parser for namespaced calls

### DIFF
--- a/examples/noir/module_call.nr
+++ b/examples/noir/module_call.nr
@@ -1,0 +1,24 @@
+mod utils {
+    pub fn inc(x: Field) -> Field {
+        x + 1
+    }
+}
+
+fn use_utils() {
+    utils::inc(5);
+}
+
+struct Dummy {}
+
+impl Dummy {
+    fn helper(self) {}
+    fn call(self) {
+        self.helper();
+    }
+}
+
+fn main() {
+    use_utils();
+    let d = Dummy {};
+    d.call();
+}

--- a/test/noirParser.test.ts
+++ b/test/noirParser.test.ts
@@ -100,4 +100,11 @@ describe('parseNoirContract', () => {
       { from: 'main', to: 'has_majority', label: '' }
     ]);
   });
+
+  it('parses the module_call.nr example file', () => {
+    const fs = require('fs');
+    const code = fs.readFileSync('examples/noir/module_call.nr', 'utf8');
+    const graph = parseNoirContract(code);
+    expect(graph.edges).to.deep.include({ from: 'use_utils', to: 'utils::inc', label: '' });
+  });
 });


### PR DESCRIPTION
## Summary
- support `call_expression` nodes in Noir parser
- detect scoped and `self.` calls
- add Noir example demonstrating module and self calls
- cover namespaced call edges in tests

## Testing
- `npm install --ignore-scripts`
- `TS_NODE_COMPILER_OPTIONS='{"esModuleInterop":true}' TS_NODE_TRANSPILE_ONLY=1 npm test` *(fails: No native build was found)*

------
https://chatgpt.com/codex/tasks/task_e_684484cd4d188328a966c2c0ddf3a1f3