### PR TITLE
Add Noir module & impl parsing

### DIFF
--- a/examples/noir/dummy.nr
+++ b/examples/noir/dummy.nr
@@ -1,0 +1,8 @@
+pub struct Dummy {}
+
+impl Dummy {
+    fn helper(self) {}
+    fn call(self) {
+        self.helper();
+    }
+}

--- a/examples/noir/impl_main.nr
+++ b/examples/noir/impl_main.nr
@@ -1,0 +1,6 @@
+mod dummy;
+
+fn main() {
+    let d = Dummy {};
+    d.call();
+}

--- a/examples/noir/import_main.nr
+++ b/examples/noir/import_main.nr
@@ -1,0 +1,6 @@
+mod utils;
+use utils::math::double;
+
+fn main() {
+    double(3);
+}

--- a/examples/noir/utils/math.nr
+++ b/examples/noir/utils/math.nr
@@ -1,0 +1,3 @@
+pub fn double(x: Field) -> Field {
+    x + x
+}

--- a/examples/noir/utils/mod.nr
+++ b/examples/noir/utils/mod.nr
@@ -1,0 +1,1 @@
+pub mod math;


### PR DESCRIPTION
## Summary
- extend Noir parser with module detection and struct `impl` support
- follow Noir `mod` and `use` imports across files
- add Noir examples exercising module imports and impl methods
- extend Noir parser tests for new behaviour

## Testing
- `npm test` *(fails: Cannot find module '@parser/move')*

------
https://chatgpt.com/codex/tasks/task_e_68448da1b9c88328b013490bc0a753fb