### PR TITLE
Improve Noir path normalization

### DIFF
--- a/src/parser/noirParser.ts
+++ b/src/parser/noirParser.ts
@@ -123,9 +123,21 @@ export function noirAstToGraph(ast: NoirAST): ContractGraph {
         call.childForFieldName("function") ||
         call.namedChildren.find((c) => c.type !== "arguments");
       if (!funcNode) continue;
-      let to = funcNode.text;
+      let to = funcNode.text.trim();
       to = to.replace(/^self\./, "");
-      to = to.replace(/<.*>/, "");
+      to = to.replace(/<[^>]*>/g, "");
+      if (to.endsWith("::")) to = to.slice(0, -2);
+      if (to.includes(".")) {
+        const parts = to.split(".");
+        if (parts.length === 2) {
+          const [obj, method] = parts;
+          if (/^[A-Z]/.test(obj)) {
+            to = `${obj}::${method}`;
+          } else {
+            to = `${obj}::${method}`;
+          }
+        }
+      }
       const key = `${from}->${to}`;
       if (!edgeSet.has(key)) {
         edgeSet.add(key);

--- a/test/noirParser.test.ts
+++ b/test/noirParser.test.ts
@@ -111,6 +111,26 @@ describe('parseNoirContract', () => {
     expect(graph.edges).to.deep.include({ from: 'Dummy::call', to: 'Dummy::helper', label: '' });
   });
 
+  it('resolves namespaced and method call paths', () => {
+    const code = [
+      'mod utils {',
+      '  pub fn inc<T>(x: T) -> T { x }',
+      '}',
+      'struct Dummy {}',
+      'impl Dummy {',
+      '  fn call(self) {}',
+      '}',
+      'fn main() {',
+      '  utils::inc::<Field>(5);',
+      '  let d = Dummy {};',
+      '  d.call();',
+      '}',
+    ].join('\n');
+    const graph = parseNoirContract(code);
+    expect(graph.edges).to.deep.include({ from: 'main', to: 'utils::inc', label: '' });
+    expect(graph.edges).to.deep.include({ from: 'main', to: 'Dummy::call', label: '' });
+  });
+
   it('follows mod statements across files', async () => {
     const fs = require('fs');
     const code = fs.readFileSync('examples/noir/import_main.nr', 'utf8');


### PR DESCRIPTION
## Summary
- better normalize Noir path expressions
- keep module paths and handle method calls
- verify namespaced and method edges in tests

## Testing
- `TS_NODE_TRANSPILE_ONLY=1 node node_modules/mocha/bin/mocha -r ts-node/register test/noirParser.test.ts` *(fails: Module._compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_684490b7d0088328b38b029a25aaa4d5