### PR TITLE
Handle Noir module paths

### DIFF
--- a/test/noirParser.test.ts
+++ b/test/noirParser.test.ts
@@ -106,7 +106,9 @@ describe('parseNoirContract', () => {
     const code = fs.readFileSync('examples/noir/module_call.nr', 'utf8');
     const graph = parseNoirContract(code);
     const ids = graph.nodes.map(n => n.id);
-    expect(ids).to.include.members(['Dummy::helper', 'Dummy::call']);
+    expect(ids).to.include.members(['Dummy::helper', 'Dummy::call', 'utils::inc']);
+    const incNode = graph.nodes.find(n => n.id === 'utils::inc');
+    expect(incNode?.contractName).to.equal('utils');
     expect(graph.edges).to.deep.include({ from: 'use_utils', to: 'utils::inc', label: '' });
     expect(graph.edges).to.deep.include({ from: 'Dummy::call', to: 'Dummy::helper', label: '' });
   });
@@ -127,6 +129,10 @@ describe('parseNoirContract', () => {
       '}',
     ].join('\n');
     const graph = parseNoirContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.include('utils::inc');
+    const incNode = graph.nodes.find(n => n.id === 'utils::inc');
+    expect(incNode?.contractName).to.equal('utils');
     expect(graph.edges).to.deep.include({ from: 'main', to: 'utils::inc', label: '' });
     expect(graph.edges).to.deep.include({ from: 'main', to: 'Dummy::call', label: '' });
   });

--- a/test/visualizer.test.ts
+++ b/test/visualizer.test.ts
@@ -21,6 +21,7 @@ mock('vscode', {
 });
 
 import { generateMermaidDiagram, clusterNodes, createVisualizationPanel } from '../src/visualization/visualizer';
+import { parseNoirContract } from '../src/languages/noir';
 import { ContractGraph } from '../src/types/graph';
 import { GraphNodeKind } from '../src/types/graphNodeKind';
 
@@ -111,6 +112,20 @@ describe('Visualizer', () => {
             expect(diagram).to.include('bar_regular[["bar"]]');
             expect(diagram).to.include('start_regular --> foo_regular');
             expect(diagram).to.include('foo_regular --> bar_regular');
+        });
+
+        it('labels clusters using module names for Noir graphs', () => {
+            const code = [
+                'mod utils {',
+                '  pub fn inc(x: Field) -> Field { x }',
+                '}',
+                'fn main() {',
+                '  utils::inc(5);',
+                '}',
+            ].join('\n');
+            const graph = parseNoirContract(code);
+            const diagram = generateMermaidDiagram(graph);
+            expect(diagram).to.include('subgraph Cluster_0["utils"]');
         });
 
         it('filters parameter comments in edge labels', () => {


### PR DESCRIPTION
## Summary
- track module name when parsing Noir functions
- set graph node contract name to module name
- test module names in Noir parser
- verify cluster labels for modules

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684494996df08328b380fb905318798b