### PR TITLE
Add alias resolution for Noir use statements

### DIFF
--- a/test/noirParser.test.ts
+++ b/test/noirParser.test.ts
@@ -137,6 +137,20 @@ describe('parseNoirContract', () => {
     expect(graph.edges).to.deep.include({ from: 'main', to: 'Dummy::call', label: '' });
   });
 
+  it('resolves simple alias imports', () => {
+    const code = [
+      'mod utils {',
+      '  pub fn inc(x: Field) -> Field { x }',
+      '}',
+      'use utils::inc as add_one;',
+      'fn main() {',
+      '  add_one(5);',
+      '}',
+    ].join('\n');
+    const graph = parseNoirContract(code);
+    expect(graph.edges).to.deep.include({ from: 'main', to: 'utils::inc', label: '' });
+  });
+
   it('follows mod statements across files', async () => {
     const fs = require('fs');
     const code = fs.readFileSync('examples/noir/import_main.nr', 'utf8');


### PR DESCRIPTION
## Summary
- extend Noir AST with `uses` array capturing alias mappings
- parse `use` statements and record aliases
- map alias names when building call graph
- add regression test for alias resolution using `use utils::inc as add_one`

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449fe992e883288cba2778940931a9