### PR TITLE
Add Noir generics examples and tests

### DIFF
--- a/examples/noir/generic_impl.nr
+++ b/examples/noir/generic_impl.nr
@@ -1,0 +1,18 @@
+struct Box<T> {
+  value: T,
+}
+
+impl<T> Box<T> {
+  fn new(v: T) -> Self {
+    Box { value: v }
+  }
+
+  fn get(self) -> T {
+    self.value
+  }
+}
+
+fn main() {
+  let b = Box::<Field>::new(5);
+  b.get();
+}

--- a/examples/noir/trait_impl.nr
+++ b/examples/noir/trait_impl.nr
@@ -1,0 +1,16 @@
+trait Summable<T> {
+  fn sum(self, a: T, b: T) -> T;
+}
+
+struct Adder {}
+
+impl Summable<Field> for Adder {
+  fn sum(self, a: Field, b: Field) -> Field {
+    a + b
+  }
+}
+
+fn main() {
+  let a = Adder {};
+  a.sum(3, 4);
+}

--- a/test/noirParser.test.ts
+++ b/test/noirParser.test.ts
@@ -169,6 +169,25 @@ describe('parseNoirContract', () => {
     expect(graph.edges).to.deep.include({ from: 'Dummy::call', to: 'Dummy::helper', label: '' });
   });
 
+  it('parses generic methods in impl blocks', () => {
+    const fs = require('fs');
+    const code = fs.readFileSync('examples/noir/generic_impl.nr', 'utf8');
+    const graph = parseNoirContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.include.members(['Box::new', 'Box::get', 'main']);
+    expect(graph.edges).to.deep.include({ from: 'main', to: 'Box::new', label: '' });
+    expect(graph.edges).to.deep.include({ from: 'main', to: 'Box::get', label: '' });
+  });
+
+  it('parses trait method implementations', () => {
+    const fs = require('fs');
+    const code = fs.readFileSync('examples/noir/trait_impl.nr', 'utf8');
+    const graph = parseNoirContract(code);
+    const ids = graph.nodes.map(n => n.id);
+    expect(ids).to.include.members(['Adder::sum', 'main']);
+    expect(graph.edges).to.deep.include({ from: 'main', to: 'Adder::sum', label: '' });
+  });
+
   it('handles alias imports with nested paths', async () => {
     const fs = require('fs');
     const path = require('path');


### PR DESCRIPTION
## Summary
- add `generic_impl.nr` example showcasing generics inside impl blocks
- add `trait_impl.nr` example demonstrating trait implementations
- cover generics and trait method calls in noir parser tests

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a26030d0832898b944dc2ef58815