### PR TITLE
Update README for Noir parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Sophia (\*.aes)
   - Flint (\*.flint)
   - Fe (\*.fe)
-  - Noir (\*.nr, \*.noir) — import resolution and method parsing are experimental
+  - Noir (\*.nr, \*.noir) — full import resolution with nested modules and alias support
   - Reach (\*.reach)
   - Rell (\*.rell)
   - Rholang (\*.rho)
   - Simplicity (\*.simp)
   - Yul (\*.yul)
-  - Support for Noir is powered by [tree-sitter-noir](https://github.com/noir-lang/tree-sitter-noir). Example contracts are available in `examples/noir`. Import resolution and method parsing are currently experimental.
+  - Support for Noir is powered by [tree-sitter-noir](https://github.com/noir-lang/tree-sitter-noir). Example contracts are available in `examples/noir`. The parser now handles nested modules and aliases.
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)
@@ -204,7 +204,7 @@ npm test
 npm test test/noirParser.test.ts
 ```
 
-Once Noir import resolution and method parsing are improved, the above command verifies parsing against the example files in `examples/noir`.
+The above command verifies parsing against the example files in `examples/noir`, including nested modules and alias resolution.
 
 The project enforces minimum coverage thresholds via `nyc`:
 


### PR DESCRIPTION
## Summary
- document stable import resolution for Noir
- highlight nested modules and alias parsing
- update Noir testing instructions

## Testing
- `npm ci` *(fails: tree-sitter download 503)*
- `npm install` *(fails: tree-sitter download 503)*
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a51cccf0832881a3f8f71516997a