### PR TITLE
Refactor parsers to share DFS walk utility

### DIFF
--- a/src/languages/move/index.ts
+++ b/src/languages/move/index.ts
@@ -1,5 +1,6 @@
 import { parseMove, MoveAST } from '@parser/move';
 import { AST, Edge, LanguageAdapter } from '../../types/core';
+import { walk } from '../../parser/sharedWalk';
 
 export const movelangAdapter: LanguageAdapter = {
   fileExtensions: ['.move'],
@@ -16,18 +17,6 @@ export const movelangAdapter: LanguageAdapter = {
         funcs.set(`${m.name}::${f.name}`, { module: m.name, name: f.name, body: f.body });
       }
     }
-
-    const walk = (node: any, type: string): any[] => {
-      const res: any[] = [];
-      const stack = [node];
-      while (stack.length) {
-        const n = stack.pop();
-        if (!n) continue;
-        if (n.type === type) res.push(n);
-        stack.push(...n.namedChildren);
-      }
-      return res;
-    };
 
     for (const m of a.modules) {
       const useMap = new Map<string, string>();

--- a/src/parser/moveParser.ts
+++ b/src/parser/moveParser.ts
@@ -3,6 +3,7 @@ import Move from "tree-sitter-move";
 import { ContractGraph, ContractNode } from "../types/graph";
 import { GraphNodeKind } from "../types/graphNodeKind";
 import logger from "../logging/logger";
+import { walk } from "./sharedWalk";
 
 export interface MoveImport {
   alias: string;
@@ -150,21 +151,6 @@ export function parseMove(code: string): { ast: MoveAST; tree: Parser.Tree } {
     modules.push({ name: moduleName, address, uses, functions });
   }
   return { ast: { modules }, tree };
-}
-
-export function walk(
-  node: Parser.SyntaxNode,
-  type: string,
-): Parser.SyntaxNode[] {
-  const res: Parser.SyntaxNode[] = [];
-  const stack = [node];
-  while (stack.length) {
-    const n = stack.pop();
-    if (!n) continue;
-    if (n.type === type) res.push(n);
-    stack.push(...n.namedChildren);
-  }
-  return res;
 }
 
 export async function parseMoveContract(code: string): Promise<ContractGraph> {

--- a/src/parser/noirParser.ts
+++ b/src/parser/noirParser.ts
@@ -2,6 +2,7 @@ import Parser from "tree-sitter";
 import Noir from "tree-sitter-noir";
 import { ContractGraph, ContractNode } from "../types/graph";
 import { GraphNodeKind } from "../types/graphNodeKind";
+import { walk } from "./sharedWalk";
 
 export interface NoirFunction {
   name: string;
@@ -35,21 +36,6 @@ function getParser(): Parser {
     parser.setLanguage(Noir as any);
   }
   return parser;
-}
-
-export function walk(
-  node: Parser.SyntaxNode,
-  type: string,
-): Parser.SyntaxNode[] {
-  const res: Parser.SyntaxNode[] = [];
-  const stack = [node];
-  while (stack.length) {
-    const n = stack.pop();
-    if (!n) continue;
-    if (n.type === type) res.push(n);
-    stack.push(...n.namedChildren);
-  }
-  return res;
 }
 
 export function parseNoir(code: string): { ast: NoirAST; tree: Parser.Tree } {

--- a/src/parser/sharedWalk.ts
+++ b/src/parser/sharedWalk.ts
@@ -1,0 +1,14 @@
+import Parser from "tree-sitter";
+
+export function walk(node: Parser.SyntaxNode, type: string): Parser.SyntaxNode[] {
+  const res: Parser.SyntaxNode[] = [];
+  const stack = [node];
+  while (stack.length) {
+    const n = stack.pop();
+    if (!n) continue;
+    if (n.type === type) res.push(n);
+    stack.push(...n.namedChildren);
+  }
+  return res;
+}
+export default walk;


### PR DESCRIPTION
## Summary
- extract common DFS `walk` to `src/parser/sharedWalk.ts`
- use shared `walk` in Move and Noir parsers
- update Move language adapter

## Testing
- `npm test` *(fails: nyc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a622915883288bd64dacc8fd5ab6