### PR TITLE
Parse Noir params

### DIFF
--- a/test/noirParser.test.ts
+++ b/test/noirParser.test.ts
@@ -17,6 +17,17 @@ describe('parseNoirContract', () => {
     expect(graph.edges).to.deep.equal([{ from: 'foo', to: 'bar', label: '' }]);
   });
 
+  it('parses function parameters', () => {
+    const code = [
+      'fn add(x: Field, y: Field) -> Field {',
+      '  x + y',
+      '}',
+    ].join('\n');
+    const graph = parseNoirContract(code);
+    const addNode = graph.nodes.find(n => n.id === 'add');
+    expect(addNode?.parameters).to.deep.equal(['x', 'y']);
+  });
+
   it('parses generic functions with nested control flow', () => {
     const code = [
       'fn inner<T>(x: T) {}',


### PR DESCRIPTION
## Summary
- parse parameters for Noir functions via tree-sitter
- store parameters on graph nodes
- verify parameter parsing in tests

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a86ace288328b25a40e9cc2410a2