### PR TITLE
Add Nargo-aware import resolution for Noir

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ Developed by [PositiveWeb3](https://www.positive.com) security researchers.
   - Sophia (\*.aes)
   - Flint (\*.flint)
   - Fe (\*.fe)
-  - Noir (\*.nr, \*.noir) — full import resolution with nested modules and alias support
+  - Noir (\*.nr, \*.noir) — full import resolution with nested modules and alias support. Nargo projects are detected automatically and modules are resolved relative to `<root>/src`, including local dependencies within the workspace.
   - Reach (\*.reach)
   - Rell (\*.rell)
   - Rholang (\*.rho)
   - Simplicity (\*.simp)
   - Yul (\*.yul)
-  - Support for Noir is powered by [tree-sitter-noir](https://github.com/noir-lang/tree-sitter-noir). Example contracts are available in `examples/noir`. The parser now handles nested modules and aliases.
+  - Support for Noir is powered by [tree-sitter-noir](https://github.com/noir-lang/tree-sitter-noir). Example contracts are available in `examples/noir`. The parser now handles nested modules, aliases and Nargo project layouts.
 - Interactive diagram with cluster-based organization
 - Zoom functionality for better navigation
 - Filter functions by type (regular, impure, inline, method_id)


### PR DESCRIPTION
## Summary
- detect `Nargo.toml` in parent directories when parsing Noir code
- load modules relative to `<root>/src` and local dependencies in the workspace
- test Noir project resolution using a temporary Nargo layout
- document new capability in README

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b10fa17c83289f03d276afea3bce