### PR TITLE
Add Noir parser test cases

### DIFF
--- a/examples/noir/group_wildcard_import.nr
+++ b/examples/noir/group_wildcard_import.nr
@@ -1,0 +1,14 @@
+mod utils {
+    pub fn inc(x: Field) -> Field { x + 1 }
+    pub fn dec(x: Field) -> Field { x - 1 }
+    pub fn dbl(x: Field) -> Field { x + x }
+}
+
+use utils::{inc, dec};
+use utils::*;
+
+fn main() {
+    inc(1);
+    dec(1);
+    dbl(2);
+}

--- a/examples/noir/nargo_example/Nargo.toml
+++ b/examples/noir/nargo_example/Nargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "Example"
+
+[dependencies]
+dep = { path = "./dep" }

--- a/examples/noir/nargo_example/dep/Nargo.toml
+++ b/examples/noir/nargo_example/dep/Nargo.toml
@@ -1,0 +1,2 @@
+[package]
+name = "dep"

--- a/examples/noir/nargo_example/dep/src/helper.nr
+++ b/examples/noir/nargo_example/dep/src/helper.nr
@@ -1,0 +1,1 @@
+pub fn run() {}

--- a/examples/noir/nargo_example/src/main.nr
+++ b/examples/noir/nargo_example/src/main.nr
@@ -1,0 +1,7 @@
+mod utils;
+use dep::helper::run;
+
+fn main() {
+    utils::inc(1);
+    run();
+}

--- a/examples/noir/nargo_example/src/utils.nr
+++ b/examples/noir/nargo_example/src/utils.nr
@@ -1,0 +1,1 @@
+pub fn inc(x: Field) -> Field { x }

--- a/examples/noir/params_example.nr
+++ b/examples/noir/params_example.nr
@@ -1,0 +1,11 @@
+struct Dummy {}
+
+impl Dummy {
+    fn act(self, x: Field, y: Field) -> Field {
+        x + y
+    }
+}
+
+fn compute(a: Field, b: u32, c: bool) -> Field {
+    a
+}


### PR DESCRIPTION
## Summary
- add Noir examples for param parsing, grouped imports, wildcard imports and Nargo project
- test parameter extraction, grouped/wildcard imports and Nargo module resolution

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845236848648328abcf41e0cfb96df6