### PR TITLE
Update noir parser for module aliases

### DIFF
--- a/examples/noir/alias_module.nr
+++ b/examples/noir/alias_module.nr
@@ -1,0 +1,6 @@
+mod utils;
+use utils::math as m;
+
+fn main() {
+    m::double(4);
+}

--- a/src/parser/noirParser.ts
+++ b/src/parser/noirParser.ts
@@ -209,11 +209,17 @@ export function noirAstToGraph(ast: NoirAST): ContractGraph {
       if (useMap.has(to)) {
         to = useMap.get(to)!;
       } else {
-        for (const w of wildcard) {
-          const cand = `${w}::${to}`;
-          if (funcMap.has(cand)) {
-            to = cand;
-            break;
+        const segs = to.split("::");
+        if (segs.length > 1 && useMap.has(segs[0])) {
+          to = [useMap.get(segs[0])!, ...segs.slice(1)].join("::");
+        }
+        if (!funcMap.has(to)) {
+          for (const w of wildcard) {
+            const cand = `${w}::${to}`;
+            if (funcMap.has(cand)) {
+              to = cand;
+              break;
+            }
           }
         }
       }

--- a/test/noirParser.test.ts
+++ b/test/noirParser.test.ts
@@ -217,6 +217,14 @@ describe('parseNoirContract', () => {
     expect(graph.edges).to.deep.include({ from: 'main', to: 'utils::math::double', label: '' });
   });
 
+  it('resolves calls through a module alias', async () => {
+    const fs = require('fs');
+    const parserUtils = require('../src/parser/parserUtils');
+    const code = fs.readFileSync('examples/noir/alias_module.nr', 'utf8');
+    const graph = await parserUtils.parseContractWithImports(code, 'examples/noir/alias_module.nr', 'noir');
+    expect(graph.edges).to.deep.include({ from: 'main', to: 'utils::math::double', label: '' });
+  });
+
   it('parses grouped imports', () => {
     const fs = require('fs');
     const code = fs.readFileSync('examples/noir/group_import.nr', 'utf8');


### PR DESCRIPTION
## Summary
- update noir parser to resolve module aliases
- add module alias example
- test module alias support

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684526e93fc08328921969a40b74379b