### PR TITLE
Fix noir parser call path

### DIFF
--- a/src/parser/noirParser.ts
+++ b/src/parser/noirParser.ts
@@ -199,11 +199,7 @@ export function noirAstToGraph(ast: NoirAST): ContractGraph {
         const parts = to.split(".");
         if (parts.length === 2) {
           const [obj, method] = parts;
-          if (/^[A-Z]/.test(obj)) {
-            to = `${obj}::${method}`;
-          } else {
-            to = `${obj}::${method}`;
-          }
+          to = `${obj}::${method}`;
         }
       }
       if (useMap.has(to)) {


### PR DESCRIPTION
## Summary
- simplify function call path resolution in `noirParser`

## Testing
- `npx eslint@7 src --ext ts` *(fails: ESLint couldn't find plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68452f18f9488328b9abe479c7fe20c0