### PR TITLE
Add caching for noir imports

### DIFF
--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -38,6 +38,7 @@ import * as toml from 'toml';
 import logger from '../logging/logger';
 
 const parseCache = new Map<string, ContractGraph>();
+const noirFileCache = new Map<string, string>();
 
 if (vscode.workspace && typeof vscode.workspace.onDidChangeTextDocument === 'function') {
     vscode.workspace.onDidChangeTextDocument(e => {
@@ -400,8 +401,11 @@ export async function parseContractWithImports(
         async function load(file: string): Promise<string> {
             const resolved = path.resolve(file);
             if (visited.has(resolved)) return '';
-            if (!(await exists(resolved))) return '';
             visited.add(resolved);
+            if (noirFileCache.has(resolved)) {
+                return noirFileCache.get(resolved)!;
+            }
+            if (!(await exists(resolved))) return '';
             let text = '';
             try {
                 text = await fsp.readFile(resolved, 'utf8');
@@ -432,6 +436,7 @@ export async function parseContractWithImports(
                 }
             }
             out += `\n\n${text}`;
+            noirFileCache.set(resolved, out);
             return out;
         }
 

--- a/test/noirImportCache.test.ts
+++ b/test/noirImportCache.test.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import mock = require('mock-require');
+
+// stub vscode so workspace utilities function
+mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) }, workspace: { workspaceFolders: [{ uri: { fsPath: '/proj' } }] } });
+
+
+describe('Noir import cache', () => {
+  afterEach(() => {
+    mock.stop('fs');
+    mock.stop('../src/parser/parserUtils');
+  });
+
+  it('reads a module referenced twice only once', async () => {
+    const files: Record<string, string> = {
+      '/proj/src/main.nr': [
+        'mod utils;',
+        'use utils::helper;',
+        'fn main() { helper::double(); }'
+      ].join('\n'),
+      '/proj/src/utils/mod.nr': 'pub mod helper;',
+      '/proj/src/utils/helper.nr': 'pub fn double() {}',
+    };
+
+    let reads = 0;
+    const fsStub = {
+      promises: {
+        access: async (p: string) => {
+          if (!(p in files)) throw new Error('not found');
+        },
+        readFile: async (p: string, _e: string) => {
+          reads++;
+          if (!(p in files)) throw new Error('not found');
+          return files[p];
+        }
+      },
+      existsSync: (p: string) => p in files,
+      readdirSync: () => []
+    };
+
+    mock('fs', fsStub);
+
+    const parserUtils = require('../src/parser/parserUtils');
+
+    const code = files['/proj/src/main.nr'];
+    await parserUtils.parseContractWithImports(code, '/proj/src/main.nr', 'noir');
+    expect(reads).to.equal(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add noirFileCache map to reuse parsed Noir modules
- return cached modules before reading disk in parseContractWithImports
- regression test for duplicate Noir import reads

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845456e30c48328a7606a5382ffdea6