### PR TITLE
Fix noir cache invalidation

### DIFF
--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -43,6 +43,18 @@ const noirFileCache = new Map<string, string>();
 if (vscode.workspace && typeof vscode.workspace.onDidChangeTextDocument === 'function') {
     vscode.workspace.onDidChangeTextDocument(e => {
         parseCache.delete(`${e.document.uri.toString()}-${detectLanguage(e.document.fileName)}`);
+        const abs = path.resolve(e.document.uri.fsPath);
+        noirFileCache.delete(abs);
+    });
+}
+
+if (vscode.workspace && typeof vscode.workspace.onDidDeleteFiles === 'function') {
+    vscode.workspace.onDidDeleteFiles(e => {
+        for (const file of e.files) {
+            parseCache.delete(`${file.toString()}-${detectLanguage(file.fsPath)}`);
+            const abs = path.resolve(file.fsPath);
+            noirFileCache.delete(abs);
+        }
     });
 }
 

--- a/test/noirImportCache.test.ts
+++ b/test/noirImportCache.test.ts
@@ -1,14 +1,26 @@
 import { expect } from 'chai';
 import mock = require('mock-require');
 
-// stub vscode so workspace utilities function
-mock('vscode', { window: { createOutputChannel: () => ({ appendLine: () => {} }) }, workspace: { workspaceFolders: [{ uri: { fsPath: '/proj' } }] } });
+let changeCb: any;
+
+beforeEach(() => {
+  changeCb = undefined;
+  mock('vscode', {
+    window: { createOutputChannel: () => ({ appendLine: () => {} }) },
+    workspace: {
+      workspaceFolders: [{ uri: { fsPath: '/proj' } }],
+      onDidChangeTextDocument: (cb: any) => { changeCb = cb; },
+      onDidDeleteFiles: () => {},
+    },
+  });
+});
 
 
 describe('Noir import cache', () => {
   afterEach(() => {
     mock.stop('fs');
     mock.stop('../src/parser/parserUtils');
+    mock.stop('vscode');
   });
 
   it('reads a module referenced twice only once', async () => {
@@ -45,5 +57,47 @@ describe('Noir import cache', () => {
     const code = files['/proj/src/main.nr'];
     await parserUtils.parseContractWithImports(code, '/proj/src/main.nr', 'noir');
     expect(reads).to.equal(3);
+  });
+
+  it('reloads modules when files change', async () => {
+    const files: Record<string, string> = {
+      '/proj/src/main.nr': [
+        'mod utils;',
+        'use utils::helper;',
+        'fn main() { helper::double(); }'
+      ].join('\n'),
+      '/proj/src/utils/mod.nr': 'pub mod helper;',
+      '/proj/src/utils/helper.nr': 'pub fn double() {}',
+    };
+
+    let reads = 0;
+    const fsStub = {
+      promises: {
+        access: async (p: string) => {
+          if (!(p in files)) throw new Error('not found');
+        },
+        readFile: async (p: string, _e: string) => {
+          reads++;
+          if (!(p in files)) throw new Error('not found');
+          return files[p];
+        }
+      },
+      existsSync: (p: string) => p in files,
+      readdirSync: () => []
+    };
+
+    mock('fs', fsStub);
+
+    const parserUtils = require('../src/parser/parserUtils');
+
+    const code = files['/proj/src/main.nr'];
+    await parserUtils.parseContractWithImports(code, '/proj/src/main.nr', 'noir');
+    expect(reads).to.equal(3);
+
+    files['/proj/src/utils/helper.nr'] = 'pub fn triple() {}';
+    changeCb({ document: { uri: { toString: () => 'file:///proj/src/utils/helper.nr', fsPath: '/proj/src/utils/helper.nr' }, fileName: '/proj/src/utils/helper.nr' } });
+
+    await parserUtils.parseContractWithImports(code, '/proj/src/main.nr', 'noir');
+    expect(reads).to.equal(4);
   });
 });


### PR DESCRIPTION
## Summary
- invalidate noirFileCache when files change or get deleted
- test noir cache reloads on file change

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_684697be311083289a81c5f7ba0161df