### PR TITLE
Add esModuleInterop option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "sourceMap": true,
         "strict": true,
         "noImplicitAny": true,
+        "esModuleInterop": true,
         "types": ["node", "vscode", "mocha"],
         "skipLibCheck": true,
         "lib": [


### PR DESCRIPTION
## Summary
- enable `esModuleInterop` in `tsconfig.json`

## Testing
- `npm run compile` *(fails: Cannot find type definition file for 'mocha', 'node', 'vscode')*

------
https://chatgpt.com/codex/tasks/task_e_68469baf64a083289a63d36999b528b7