### PR TITLE
Add custom type for tree-sitter-noir

### DIFF
--- a/src/types/tree-sitter-noir.d.ts
+++ b/src/types/tree-sitter-noir.d.ts
@@ -1,0 +1,1 @@
+declare module "tree-sitter-noir";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     },
     "include": [
         "src",
+        "src/types"
     ],
     "exclude": [
         "node_modules",


### PR DESCRIPTION
## Summary
- add declaration file `tree-sitter-noir.d.ts`
- ensure `src/types` is explicitly included in the TypeScript config

## Testing
- `npm run compile` *(fails: Cannot find type definition file for 'mocha' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68469d9817808328b1beb1cdd8a953aa