### PR TITLE
Fix parser callback types

### DIFF
--- a/src/parser/moveParser.ts
+++ b/src/parser/moveParser.ts
@@ -79,11 +79,11 @@ export function parseMove(code: string): { ast: MoveAST; tree: Parser.Tree } {
     if (body) {
       for (const child of body.namedChildren) {
         if (child.type === "use_declaration") {
-          const pathNode = child.namedChildren.find((c) => c.type === "path");
+          const pathNode = child.namedChildren.find((c: Parser.SyntaxNode) => c.type === "path");
           if (!pathNode) continue;
-          const aliasNode = child.namedChildren.find((c) => c.type === "alias");
+          const aliasNode = child.namedChildren.find((c: Parser.SyntaxNode) => c.type === "alias");
           const items = child.namedChildren.filter(
-            (c) => c.type === "use_item",
+            (c: Parser.SyntaxNode) => c.type === "use_item",
           );
           if (items.length === 0) {
             const path = pathNode.text;
@@ -92,9 +92,9 @@ export function parseMove(code: string): { ast: MoveAST; tree: Parser.Tree } {
           } else {
             for (const it of items) {
               const itemAlias = it.namedChildren.find(
-                (c) => c.type === "alias",
+                (c: Parser.SyntaxNode) => c.type === "alias",
               );
-              const itemPath = it.namedChildren.find((c) => c.type === "path");
+              const itemPath = it.namedChildren.find((c: Parser.SyntaxNode) => c.type === "path");
               const name = itemPath ? itemPath.text : it.text;
               const alias = itemAlias
                 ? itemAlias.text
@@ -195,7 +195,7 @@ export async function parseMoveContract(code: string): Promise<ContractGraph> {
       for (const call of calls) {
         const access =
           call.namedChildren[0]?.namedChildren?.find(
-            (c: any) => c.fieldName === "access",
+            (c: Parser.SyntaxNode) => c.fieldName === "access",
           ) || call.childForFieldName("access");
         let path = access ? access.text : "";
         if (!path) continue;

--- a/src/parser/noirParser.ts
+++ b/src/parser/noirParser.ts
@@ -52,21 +52,21 @@ export function parseNoir(code: string): { ast: NoirAST; tree: Parser.Tree } {
   const uses: NoirUse[] = [];
   const fnNodes = walk(tree.rootNode, "function_definition");
   for (const fn of fnNodes) {
-    const idNode = fn.namedChildren.find((c) => c.type === "identifier");
-    const bodyNode = fn.namedChildren.find((c) => c.type === "body");
-    const paramNode = fn.namedChildren.find((c) => c.type === "parameter");
+    const idNode = fn.namedChildren.find((c: Parser.SyntaxNode) => c.type === "identifier");
+    const bodyNode = fn.namedChildren.find((c: Parser.SyntaxNode) => c.type === "body");
+    const paramNode = fn.namedChildren.find((c: Parser.SyntaxNode) => c.type === "parameter");
     if (idNode) {
       const modulePath: string[] = [];
       let structName: string | null = null;
       let parent: Parser.SyntaxNode | null = fn.parent;
       while (parent) {
         if (parent.type === "struct_method" && !structName) {
-          const structId = parent.namedChildren.find((c) => c.type === "identifier");
+          const structId = parent.namedChildren.find((c: Parser.SyntaxNode) => c.type === "identifier");
           if (structId) {
             structName = structId.text;
           }
         } else if (parent.type === "module") {
-          const modId = parent.namedChildren.find((c) => c.type === "identifier");
+          const modId = parent.namedChildren.find((c: Parser.SyntaxNode) => c.type === "identifier");
           if (modId) {
             modulePath.unshift(modId.text);
           }
@@ -87,7 +87,7 @@ export function parseNoir(code: string): { ast: NoirAST; tree: Parser.Tree } {
           } else if (p.type === "self_method") {
             params.push("self");
           } else if (p.type === "as_identifier") {
-            const id = p.namedChildren.find(c => c.type === "identifier");
+            const id = p.namedChildren.find((c: Parser.SyntaxNode) => c.type === "identifier");
             if (id) params.push(id.text);
           }
         }
@@ -105,8 +105,8 @@ export function parseNoir(code: string): { ast: NoirAST; tree: Parser.Tree } {
 
   const moduleNodes = walk(tree.rootNode, "module");
   for (const m of moduleNodes) {
-    const idNode = m.namedChildren.find((c) => c.type === "identifier");
-    const bodyNode = m.namedChildren.find((c) => c.type === "body");
+    const idNode = m.namedChildren.find((c: Parser.SyntaxNode) => c.type === "identifier");
+    const bodyNode = m.namedChildren.find((c: Parser.SyntaxNode) => c.type === "body");
     if (idNode) {
       modules.push({ name: idNode.text, body: bodyNode });
     }
@@ -127,7 +127,7 @@ export function parseNoir(code: string): { ast: NoirAST; tree: Parser.Tree } {
         const base = g[1].trim();
         const items = g[2]
           .split(',')
-          .map(s => s.trim())
+          .map((s: string) => s.trim())
           .filter(Boolean);
         for (const it of items) {
           if (it === '*') {
@@ -189,7 +189,7 @@ export function noirAstToGraph(ast: NoirAST): ContractGraph {
     for (const call of calls) {
       const funcNode =
         call.childForFieldName("function") ||
-        call.namedChildren.find((c) => c.type !== "arguments");
+        call.namedChildren.find((c: Parser.SyntaxNode) => c.type !== "arguments");
       if (!funcNode) continue;
       let to = funcNode.text.trim();
       to = to.replace(/^self\./, "");

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -68,9 +68,9 @@ function collectNoirImports(code: string): string[] {
         const node = stack.pop();
         if (!node) continue;
         if (node.type === 'module') {
-            const body = node.namedChildren.find(c => c.type === 'body');
+            const body = node.namedChildren.find((c: Parser.SyntaxNode) => c.type === 'body');
             if (!body) {
-                const id = node.namedChildren.find(c => c.type === 'identifier');
+                const id = node.namedChildren.find((c: Parser.SyntaxNode) => c.type === 'identifier');
                 if (id) result.add(id.text);
             }
         }


### PR DESCRIPTION
## Summary
- type annotate all `find`/`filter` callbacks in parsers
- fix noir parser `.map` callback typing

## Testing
- `npm run compile` *(fails: Cannot find type definition file for 'mocha')*

------
https://chatgpt.com/codex/tasks/task_e_68469fd926148328a1c8460eb215a4cb