### PR TITLE
Add Noir public function type

### DIFF
--- a/src/parser/noirParser.ts
+++ b/src/parser/noirParser.ts
@@ -11,6 +11,7 @@ export interface NoirFunction {
   startPosition: Parser.Point;
   endPosition: Parser.Point;
   params: string[];
+  isPublic?: boolean;
 }
 
 export interface NoirModule {
@@ -92,6 +93,8 @@ export function parseNoir(code: string): { ast: NoirAST; tree: Parser.Tree } {
           }
         }
       }
+      const pre = code.slice(Math.max(0, fn.startIndex - 4), fn.startIndex);
+      const isPublic = /\bpub\s*$/.test(pre);
       functions.push({
         name: prefix + idNode.text,
         moduleName: modulePath.join("::") || undefined,
@@ -99,6 +102,7 @@ export function parseNoir(code: string): { ast: NoirAST; tree: Parser.Tree } {
         startPosition: fn.startPosition,
         endPosition: fn.endPosition,
         params,
+        isPublic,
       });
     }
   }
@@ -173,7 +177,7 @@ export function noirAstToGraph(ast: NoirAST): ContractGraph {
       type: GraphNodeKind.Function,
       contractName: f.moduleName || "Contract",
       parameters: f.params || [],
-      functionType: "regular",
+      functionType: f.isPublic ? "public" : "regular",
     };
     graph.nodes.push(node);
     funcMap.set(f.name, node);

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -520,6 +520,12 @@ export function getFunctionTypeFilters(language: ContractLanguage): { value: str
         case 'sophia':
         case 'marlowe':
         case 'yul':
+            if (language === 'noir') {
+                return [
+                    { value: 'regular', label: 'Regular' },
+                    { value: 'public', label: 'Public' }
+                ];
+            }
             return [
                 { value: 'regular', label: 'Regular' }
             ];

--- a/test/noirParser.test.ts
+++ b/test/noirParser.test.ts
@@ -28,6 +28,18 @@ describe('parseNoirContract', () => {
     expect(addNode?.parameters).to.deep.equal(['x', 'y']);
   });
 
+  it('detects public and regular functions', () => {
+    const code = [
+      'pub fn visible() {}',
+      'fn hidden() {}',
+    ].join('\n');
+    const graph = parseNoirContract(code);
+    const pubNode = graph.nodes.find(n => n.id === 'visible');
+    const regNode = graph.nodes.find(n => n.id === 'hidden');
+    expect(pubNode?.functionType).to.equal('public');
+    expect(regNode?.functionType).to.equal('regular');
+  });
+
   it('parses generic functions with nested control flow', () => {
     const code = [
       'fn inner<T>(x: T) {}',

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -124,6 +124,8 @@ describe('Parser', () => {
         const moveFilters = getFunctionTypeFilters('move').map(f => f.value);
         expect(moveFilters).to.include('entry');
         expect(moveFilters).to.include('script');
+        const noirFilters = getFunctionTypeFilters('noir').map(f => f.value);
+        expect(noirFilters).to.include('public');
     });
 
     it('parses contract with imports', async () => {


### PR DESCRIPTION
## Summary
- parse and track public Noir functions
- mark public functions in Noir AST-to-graph conversion
- expose `public` filter for Noir language
- test public/regular Noir functions and filters

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a639fb5c8328af396135b66142d7