### PR TITLE
Fix TypeScript compile errors

### DIFF
--- a/src/parser/moveParser.ts
+++ b/src/parser/moveParser.ts
@@ -120,6 +120,7 @@ export function parseMove(code: string): { ast: MoveAST; tree: Parser.Tree } {
                 isPublic = true;
                 for (let i = 0; i < sc.childCount; i++) {
                   const ch = sc.child(i);
+                  if (!ch) continue;
                   const txt = ch.text;
                   if (txt === "friend") {
                     isFriend = true;
@@ -195,7 +196,7 @@ export async function parseMoveContract(code: string): Promise<ContractGraph> {
       for (const call of calls) {
         const access =
           call.namedChildren[0]?.namedChildren?.find(
-            (c: Parser.SyntaxNode) => c.fieldName === "access",
+            (c: any) => c.fieldName === "access",
           ) || call.childForFieldName("access");
         let path = access ? access.text : "";
         if (!path) continue;

--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -33,6 +33,7 @@ import { parseRellContract } from '../languages/rell';
 import { parseRholangContract } from '../languages/rholang';
 import { parseMarloweContract } from '../languages/marlowe';
 import { parseYulContract } from '../languages/yul';
+import Parser from 'tree-sitter';
 import * as vscode from 'vscode';
 import * as toml from 'toml';
 import logger from '../logging/logger';


### PR DESCRIPTION
## Summary
- ensure tree-sitter is imported in parser utils
- handle null children when scanning modifiers
- loosen typing for access node search

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: nyc not found)*
- `npm run compile` *(fails: missing type definition files)*
- `npm audit`

------
https://chatgpt.com/codex/tasks/task_e_6846ac80cee883289b107676725cfb87