### PR TITLE
Fix module path detection

### DIFF
--- a/src/parser/moveParser.ts
+++ b/src/parser/moveParser.ts
@@ -209,12 +209,13 @@ export async function parseMoveContract(code: string): Promise<ContractGraph> {
         if (!edgeSet.has(key)) {
           edgeSet.add(key);
           if (!funcMap.has(to)) {
+            const parts = to.split("::");
+            const funcName = parts.pop() || to;
             graph.nodes.push({
               id: to,
-              label: path,
+              label: `${funcName}()`,
               type: GraphNodeKind.Function,
-              contractName:
-                path.split("::")[path.split("::").length - 2] || path,
+              contractName: parts.join("::") || to,
             });
             funcMap.set(to, graph.nodes[graph.nodes.length - 1]);
           }

--- a/src/parser/noirParser.ts
+++ b/src/parser/noirParser.ts
@@ -171,9 +171,10 @@ export function noirAstToGraph(ast: NoirAST): ContractGraph {
   });
 
   for (const f of ast.functions) {
+    const funcParts = f.name.split("::");
     const node: ContractNode = {
       id: f.name,
-      label: `${f.name}()`,
+      label: `${funcParts[funcParts.length - 1]}()`,
       type: GraphNodeKind.Function,
       contractName: f.moduleName || "Contract",
       parameters: f.params || [],
@@ -227,11 +228,13 @@ export function noirAstToGraph(ast: NoirAST): ContractGraph {
       if (!edgeSet.has(key)) {
         edgeSet.add(key);
         if (!funcMap.has(to)) {
+          const parts = to.split("::");
+          const funcName = parts.pop() || to;
           graph.nodes.push({
             id: to,
-            label: `${to}()`,
+            label: `${funcName}()`,
             type: GraphNodeKind.Function,
-            contractName: "Contract",
+            contractName: parts.join("::") || "Contract",
           });
           funcMap.set(to, graph.nodes[graph.nodes.length - 1]);
         }


### PR DESCRIPTION
## Summary
- properly split Move and Noir paths for node labels and clusters
- test Move parser clusters external module
- test Noir parser clusters external module

## Testing
- `npm test` *(fails: nyc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b387b6648328b5f1a0c697180966