### PR TITLE
Improve diagnostics for Noir parsing

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import logger from './logging/logger';
 import adapters from './languages';
 import { GraphProvider } from './core/graphProvider';
 import { startMoveClient } from './lsp-clients/moveClient';
+import { diagnosticCollection } from './logging/diagnostics';
 
 export function activate(context: vscode.ExtensionContext) {
     logger.info('Activating TON Graph extension');
@@ -17,6 +18,8 @@ export function activate(context: vscode.ExtensionContext) {
         // Directory might already exist, that's fine
         logger.debug('Cached directory already exists');
     }
+
+    context.subscriptions.push(diagnosticCollection);
 
     adapters.forEach(adapter => {
         adapter.fileExtensions.forEach(ext => {

--- a/src/logging/diagnostics.ts
+++ b/src/logging/diagnostics.ts
@@ -1,0 +1,14 @@
+import * as vscode from 'vscode';
+
+export const diagnosticCollection = vscode.languages.createDiagnosticCollection('ton-graph');
+
+export function reportDiagnostic(uri: vscode.Uri, message: string, line = 0, column = 0): void {
+  const range = new vscode.Range(line, column, line, column + 1);
+  const diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
+  diagnosticCollection.set(uri, [diagnostic]);
+}
+
+export function clearDiagnostics(uri: vscode.Uri): void {
+  diagnosticCollection.delete(uri);
+}
+


### PR DESCRIPTION
## Summary
- add diagnostic utilities
- use diagnostics in visualize command
- register diagnostics in extension

## Testing
- `npm test` *(fails: nyc not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run compile` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6846b6389e80832884b332a97b702771