### PR TITLE
Add Noir import cache invalidation test

### DIFF
--- a/test/noirImportCache.test.ts
+++ b/test/noirImportCache.test.ts
@@ -100,4 +100,49 @@ describe('Noir import cache', () => {
     await parserUtils.parseContractWithImports(code, '/proj/src/main.nr', 'noir');
     expect(reads).to.equal(4);
   });
+
+  it('re-reads changed imports on subsequent parse calls', async () => {
+    const files: Record<string, string> = {
+      '/proj/src/main.nr': [
+        'mod utils;',
+        'use utils::helper;',
+        'fn main() { helper::double(); }'
+      ].join('\n'),
+      '/proj/src/utils/mod.nr': 'pub mod helper;',
+      '/proj/src/utils/helper.nr': 'pub fn double() {}',
+    };
+
+    let reads = 0;
+    const fsStub = {
+      promises: {
+        access: async (p: string) => {
+          if (!(p in files)) throw new Error('not found');
+        },
+        readFile: async (p: string, _e: string) => {
+          reads++;
+          if (!(p in files)) throw new Error('not found');
+          return files[p];
+        }
+      },
+      existsSync: (p: string) => p in files,
+      readdirSync: () => []
+    };
+
+    mock('fs', fsStub);
+
+    const parserUtils = require('../src/parser/parserUtils');
+
+    const code = files['/proj/src/main.nr'];
+    await parserUtils.parseContractWithImports(code, '/proj/src/main.nr', 'noir');
+    expect(reads).to.equal(3);
+
+    await parserUtils.parseContractWithImports(code, '/proj/src/main.nr', 'noir');
+    expect(reads).to.equal(3);
+
+    files['/proj/src/utils/helper.nr'] = 'pub fn triple() {}';
+    changeCb({ document: { uri: { toString: () => 'file:///proj/src/utils/helper.nr', fsPath: '/proj/src/utils/helper.nr' }, fileName: '/proj/src/utils/helper.nr' } });
+
+    await parserUtils.parseContractWithImports(code, '/proj/src/main.nr', 'noir');
+    expect(reads).to.equal(4);
+  });
 });


### PR DESCRIPTION
## Summary
- expand Noir cache test coverage to check subsequent parses after a file change

## Testing
- `npm test test/noirImportCache.test.ts` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bcad7e5883288f3a6a95071498bf