### PR TITLE
fix(parser): add missing walk import

### DIFF
--- a/src/parser/parserUtils.ts
+++ b/src/parser/parserUtils.ts
@@ -26,6 +26,7 @@ import { parseSophiaContract } from '../languages/sophia';
 import { parseFlintContract } from '../languages/flint';
 import { parseFeContract } from '../languages/fe';
 import { parseNoirContract, parseNoir } from './noirParser';
+import { walk } from './sharedWalk';
 import { parseSimplicityContract } from '../languages/simplicity';
 import { parseLiquidityContract } from '../languages/liquidity';
 import { parseReachContract } from '../languages/reach';


### PR DESCRIPTION
## Summary
- add missing import for `walk` in `parserUtils`

## Testing
- `npx tsc -p ./`

------
https://chatgpt.com/codex/tasks/task_e_6846c18af548832899ac69f9a4bd6882