### PR TITLE
Add verbose logging for VSCode extension

### DIFF
--- a/src/export/exportHandler.ts
+++ b/src/export/exportHandler.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { filterMermaidDiagram, generateVisualizationHtml } from '../visualization/templates';
+import { logger } from '../logger';
 
 // Reference to cached Mermaid URI
 let cachedMermaidUri: vscode.Uri | undefined;
@@ -48,7 +49,7 @@ export async function handleExport(
                 break;
         }
     } catch (error: any) {
-        console.error('Error handling export:', error);
+        logger.error(`Error handling export: ${error.message || String(error)}`);
         vscode.window.showErrorMessage(`Error handling export: ${error.message || String(error)}`);
         panel.webview.postMessage({
             command: 'saveResult',
@@ -82,7 +83,7 @@ async function handleApplyFilters(
         const originalGraph = response.content;
 
         if (!originalGraph) {
-            console.error('No original graph data received');
+            logger.error('No original graph data received');
             throw new Error('No original graph data received');
         }
 
@@ -113,11 +114,11 @@ async function handleApplyFilters(
                 nameFilter
             });
         } catch (updateError) {
-            console.error('Error updating webview content:', updateError);
+            logger.error(`Error updating webview content: ${updateError instanceof Error ? updateError.message : String(updateError)}`);
             throw updateError;
         }
     } catch (error: any) {
-        console.error('Error applying filters:', error);
+        logger.error(`Error applying filters: ${error.message || String(error)}`);
         panel.webview.postMessage({
             command: 'filtersApplied',
             success: false,
@@ -147,16 +148,16 @@ async function getMermaidScriptUri(context: vscode.ExtensionContext, webview: vs
         try {
             // Check if file exists locally
             await vscode.workspace.fs.stat(localMermaidPath);
-            console.log('Using cached Mermaid library in exportHandler');
+            logger.info('Using cached Mermaid library in exportHandler');
             cachedMermaidUri = localMermaidPath;
             return webview.asWebviewUri(localMermaidPath).toString();
         } catch {
             // File doesn't exist, use CDN
-            console.log('No cached Mermaid found, using CDN in exportHandler');
+            logger.info('No cached Mermaid found, using CDN in exportHandler');
             return cdnUrl;
         }
     } catch (error) {
-        console.error('Error checking cached Mermaid:', error);
+        logger.error(`Error checking cached Mermaid: ${error instanceof Error ? error.message : String(error)}`);
         return cdnUrl;
     }
 }
@@ -264,7 +265,7 @@ async function handlePngExport(
         try {
             // Get SVG content
             const svgContent = message.content;
-            console.log('PNG export: Got SVG content, length:', svgContent.length);
+            logger.info(`PNG export: Got SVG content, length: ${svgContent.length}`);
 
             // Convert SVG to PNG using the webview
             panel.webview.postMessage({
@@ -286,7 +287,7 @@ async function handlePngExport(
                 )
             ]);
 
-            console.log('PNG export: Received response');
+            logger.info('PNG export: Received response');
 
             if (!pngResponse || !pngResponse.content) {
                 throw new Error('No PNG data received from webview');
@@ -296,7 +297,7 @@ async function handlePngExport(
 
             // Validate the data URL format
             if (!pngDataUrl.startsWith('data:image/png;base64,')) {
-                console.error('Invalid PNG data URL format:', pngDataUrl.substring(0, 50) + '...');
+                logger.error('Invalid PNG data URL format: ' + pngDataUrl.substring(0, 50) + '...');
                 throw new Error('Invalid PNG data URL format');
             }
 
@@ -312,7 +313,7 @@ async function handlePngExport(
                 path: pngUri.fsPath
             });
         } catch (error: any) {
-            console.error('Error in PNG export:', error);
+            logger.error(`Error in PNG export: ${error.message || String(error)}`);
             vscode.window.showErrorMessage(`Failed to export PNG: ${error.message}`);
             throw error;
         }
@@ -338,7 +339,7 @@ async function handleJpgExport(
         try {
             // Get SVG content
             const svgContent = message.content;
-            console.log('JPG export: Got SVG content, length:', svgContent.length);
+            logger.info(`JPG export: Got SVG content, length: ${svgContent.length}`);
 
             // Convert SVG to JPG using the webview
             panel.webview.postMessage({
@@ -360,7 +361,7 @@ async function handleJpgExport(
                 )
             ]);
 
-            console.log('JPG export: Received response');
+            logger.info('JPG export: Received response');
 
             if (!jpgResponse || !jpgResponse.content) {
                 throw new Error('No JPG data received from webview');
@@ -370,7 +371,7 @@ async function handleJpgExport(
 
             // Validate the data URL format
             if (!jpgDataUrl.startsWith('data:image/jpeg;base64,')) {
-                console.error('Invalid JPG data URL format:', jpgDataUrl.substring(0, 50) + '...');
+                logger.error('Invalid JPG data URL format: ' + jpgDataUrl.substring(0, 50) + '...');
                 throw new Error('Invalid JPG data URL format');
             }
 
@@ -386,7 +387,7 @@ async function handleJpgExport(
                 path: jpgUri.fsPath
             });
         } catch (error: any) {
-            console.error('Error in JPG export:', error);
+            logger.error(`Error in JPG export: ${error.message || String(error)}`);
             vscode.window.showErrorMessage(`Failed to export JPG: ${error.message}`);
             throw error;
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,34 +3,39 @@ import { createVisualizationPanel, generateMermaidDiagram } from './visualizatio
 import { handleExport } from './export/exportHandler';
 import { ContractGraph } from './types/graph';
 import { detectLanguage, parseContractByLanguage, getFunctionTypeFilters, parseContractWithImports } from './parser/parserUtils';
+import { logger } from './logger';
 
 export function activate(context: vscode.ExtensionContext) {
-    console.log('TON Graph extension is now active');
+    logger.info('TON Graph extension is now active');
 
     // Create the cached directory for storing the Mermaid library
     const cachedDir = vscode.Uri.joinPath(context.extensionUri, 'cached');
     try {
         vscode.workspace.fs.createDirectory(cachedDir);
-        console.log('Cached directory created/verified');
+        logger.info('Cached directory created/verified');
     } catch (err) {
         // Directory might already exist, that's fine
-        console.log('Note: Cached directory may already exist');
+        logger.info('Note: Cached directory may already exist');
     }
 
     let disposable = vscode.commands.registerCommand('ton-graph.visualize', async (fileUri?: vscode.Uri) => {
         let document: vscode.TextDocument;
         let code: string;
+        const source = fileUri ? 'explorer' : 'editor';
+        logger.info(`Command visualize triggered from ${source}`);
 
         // If invoked from explorer context menu, fileUri will be provided
         if (fileUri) {
             try {
-                // Read the file contents
+                logger.info(`Reading file ${fileUri.fsPath}`);
                 const fileData = await vscode.workspace.fs.readFile(fileUri);
                 code = Buffer.from(fileData).toString('utf8');
 
                 // Open the document to get the language mode correctly set
                 document = await vscode.workspace.openTextDocument(fileUri);
+                logger.info(`Opened document ${document.uri.fsPath}`);
             } catch (error: any) {
+                logger.error(`Could not read file: ${error.message || String(error)}`, fileUri);
                 vscode.window.showErrorMessage(`Could not read file: ${error.message || String(error)}`);
                 return;
             }
@@ -38,29 +43,34 @@ export function activate(context: vscode.ExtensionContext) {
             // Invoked from editor context menu
             const editor = vscode.window.activeTextEditor;
             if (!editor) {
+                logger.error('No active editor found');
                 vscode.window.showErrorMessage('No active editor found');
                 return;
             }
             document = editor.document;
+            logger.info(`Using active editor document ${document.uri.fsPath}`);
             code = document.getText();
         }
 
         let originalGraph: ContractGraph | null = null; // Store the original graph
-
+        
         try {
             // Detect language and use appropriate parser
             const language = detectLanguage(document.fileName);
+            logger.info(`Detected language ${language} for ${document.fileName}`);
             originalGraph = await parseContractByLanguage(code, language);
+            logger.info('Contract parsed successfully');
 
             // Create and show the webview with language-specific function type filters
             const panel = createVisualizationPanel(context, originalGraph, getFunctionTypeFilters(language));
+            logger.info('Visualization panel created');
 
             // Handle messages from the webview
             panel.webview.onDidReceiveMessage(
                 async (message) => {
                     if (message.command === 'applyFilters') {
                         if (!originalGraph) {
-                            console.error('Original graph data not available for filtering.');
+                            logger.error('Original graph data not available for filtering.', document.uri);
                             vscode.window.showErrorMessage('Cannot apply filters: original graph data is missing.');
                             return;
                         }
@@ -138,7 +148,7 @@ export function activate(context: vscode.ExtensionContext) {
                             });
 
                         } catch (filterError: any) {
-                            console.error('Error applying filters:', filterError);
+                            logger.error(`Error applying filters: ${filterError.message || String(filterError)}`, document.uri);
                             vscode.window.showErrorMessage(`Error applying filters: ${filterError.message || String(filterError)}`);
                             // Send error message back to WebView
                             panel.webview.postMessage({
@@ -158,7 +168,7 @@ export function activate(context: vscode.ExtensionContext) {
 
             panel.reveal(vscode.ViewColumn.Beside);
         } catch (error: any) {
-            console.error('Error visualizing contract:', error);
+            logger.error(`Error visualizing contract: ${error.message || String(error)}`, document.uri);
             vscode.window.showErrorMessage(`Error visualizing contract: ${error.message || String(error)}`);
             originalGraph = null; // Reset on error
         }
@@ -171,18 +181,21 @@ export function activate(context: vscode.ExtensionContext) {
         let document: vscode.TextDocument;
         let code: string;
         let filePath: string;
+        const source = fileUri ? 'explorer' : 'editor';
+        logger.info(`Command visualizeProject triggered from ${source}`);
 
         // If invoked from explorer context menu, fileUri will be provided
         if (fileUri) {
             try {
-                // Read the file contents
+                logger.info(`Reading file ${fileUri.fsPath}`);
                 const fileData = await vscode.workspace.fs.readFile(fileUri);
                 code = Buffer.from(fileData).toString('utf8');
                 filePath = fileUri.fsPath;
 
-                // Open the document to get the language mode correctly set
                 document = await vscode.workspace.openTextDocument(fileUri);
+                logger.info(`Opened document ${document.uri.fsPath}`);
             } catch (error: any) {
+                logger.error(`Could not read file: ${error.message || String(error)}`, fileUri);
                 vscode.window.showErrorMessage(`Could not read file: ${error.message || String(error)}`);
                 return;
             }
@@ -190,10 +203,12 @@ export function activate(context: vscode.ExtensionContext) {
             // Invoked from editor context menu
             const editor = vscode.window.activeTextEditor;
             if (!editor) {
+                logger.error('No active editor found');
                 vscode.window.showErrorMessage('No active editor found');
                 return;
             }
             document = editor.document;
+            logger.info(`Using active editor document ${document.uri.fsPath}`);
             code = document.getText();
             filePath = document.uri.fsPath;
         }
@@ -209,16 +224,21 @@ export function activate(context: vscode.ExtensionContext) {
 
                 // Detect language
                 const language = detectLanguage(filePath);
+                logger.info(`Detected language ${language} for ${filePath}`);
 
                 progress.report({ increment: 30, message: "Processing imports..." });
+                logger.info('Processing imports');
 
                 // Parse contract with imports
                 let originalGraph = await parseContractWithImports(code, filePath, language);
+                logger.info('Contract with imports parsed');
 
                 progress.report({ increment: 30, message: "Generating visualization..." });
+                logger.info('Generating visualization');
 
                 // Create and show the webview
                 const panel = createVisualizationPanel(context, originalGraph, getFunctionTypeFilters(language), "Contract Project Visualization");
+                logger.info('Visualization panel created for project');
 
                 // Handle messages from the webview (same as in visualize command)
                 panel.webview.onDidReceiveMessage(
@@ -298,7 +318,7 @@ export function activate(context: vscode.ExtensionContext) {
                                 });
 
                             } catch (filterError: any) {
-                                console.error('Error applying filters:', filterError);
+                                logger.error(`Error applying filters: ${filterError.message || String(filterError)}`, document.uri);
                                 vscode.window.showErrorMessage(`Error applying filters: ${filterError.message || String(filterError)}`);
                                 panel.webview.postMessage({
                                     command: 'filterError',
@@ -318,7 +338,7 @@ export function activate(context: vscode.ExtensionContext) {
                 panel.reveal(vscode.ViewColumn.Beside);
             });
         } catch (error: any) {
-            console.error('Error visualizing contract project:', error);
+            logger.error(`Error visualizing contract project: ${error.message || String(error)}`, document.uri);
             vscode.window.showErrorMessage(`Error visualizing contract project: ${error.message || String(error)}`);
         }
     });
@@ -326,4 +346,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(projectDisposable);
 }
 
-export function deactivate() { }
+export function deactivate() {
+    logger.info('TON Graph extension deactivated');
+    logger.clear();
+}

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+
+export class Logger {
+    private channel: vscode.OutputChannel;
+    private diagnostics: vscode.DiagnosticCollection;
+    private diagnosticsMap = new Map<string, vscode.Diagnostic[]>();
+
+    constructor() {
+        this.channel = vscode.window.createOutputChannel('TON Graph Logs');
+        this.diagnostics = vscode.languages.createDiagnosticCollection('ton-graph');
+    }
+
+    info(message: string, uri?: vscode.Uri) {
+        const timestamp = new Date().toISOString();
+        this.channel.appendLine(`[INFO ${timestamp}] ${message}`);
+        if (uri) {
+            this.addDiagnostic(uri, message, vscode.DiagnosticSeverity.Information);
+        }
+    }
+
+    error(message: string, uri?: vscode.Uri) {
+        const timestamp = new Date().toISOString();
+        this.channel.appendLine(`[ERROR ${timestamp}] ${message}`);
+        if (uri) {
+            this.addDiagnostic(uri, message, vscode.DiagnosticSeverity.Error);
+        }
+    }
+
+    clear(uri?: vscode.Uri) {
+        if (uri) {
+            this.diagnostics.delete(uri);
+            this.diagnosticsMap.delete(uri.toString());
+        } else {
+            this.diagnostics.clear();
+            this.diagnosticsMap.clear();
+        }
+    }
+
+    private addDiagnostic(uri: vscode.Uri, message: string, severity: vscode.DiagnosticSeverity) {
+        const diag = new vscode.Diagnostic(new vscode.Range(0, 0, 0, 1), message, severity);
+        const key = uri.toString();
+        const arr = this.diagnosticsMap.get(key) || [];
+        arr.push(diag);
+        this.diagnosticsMap.set(key, arr);
+        this.diagnostics.set(uri, arr);
+    }
+}
+
+export const logger = new Logger();

--- a/src/parser/importHandler.ts
+++ b/src/parser/importHandler.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
+import { logger } from '../logger';
 
 /**
  * Processes import statements in FunC code (#include)
@@ -39,10 +40,10 @@ export async function processFuncImports(
                 importedCode.push(nestedImports.importedCode);
                 importedFilePaths.push(...nestedImports.importedFilePaths);
             } else {
-                console.warn(`Included file not found: ${fullPath}`);
+                logger.error(`Included file not found: ${fullPath}`);
             }
         } catch (error) {
-            console.error(`Error processing import ${fullPath}:`, error);
+            logger.error(`Error processing import ${fullPath}: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 
@@ -85,7 +86,7 @@ export async function processTactImports(
                 fullPath = packagePath;
                 // Could further resolve subpaths here
             } else {
-                console.warn(`Package not found: ${packageName}`);
+                logger.error(`Package not found: ${packageName}`);
                 continue;
             }
         } else {
@@ -113,10 +114,10 @@ export async function processTactImports(
                 importedCode.push(nestedImports.importedCode);
                 importedFilePaths.push(...nestedImports.importedFilePaths);
             } else {
-                console.warn(`Imported file not found: ${fullPath}`);
+                logger.error(`Imported file not found: ${fullPath}`);
             }
         } catch (error) {
-            console.error(`Error processing import ${fullPath}:`, error);
+            logger.error(`Error processing import ${fullPath}: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 
@@ -159,7 +160,7 @@ export async function processTolkImports(
                 fullPath = packagePath;
                 // Could further resolve subpaths here
             } else {
-                console.warn(`Package not found: ${packageName}`);
+                logger.error(`Package not found: ${packageName}`);
                 continue;
             }
         } else {
@@ -187,10 +188,10 @@ export async function processTolkImports(
                 importedCode.push(nestedImports.importedCode);
                 importedFilePaths.push(...nestedImports.importedFilePaths);
             } else {
-                console.warn(`Imported file not found: ${fullPath}`);
+                logger.error(`Imported file not found: ${fullPath}`);
             }
         } catch (error) {
-            console.error(`Error processing import ${fullPath}:`, error);
+            logger.error(`Error processing import ${fullPath}: ${error instanceof Error ? error.message : String(error)}`);
         }
     }
 


### PR DESCRIPTION
## Summary
- log extension actions to a new `TON Graph Logs` output channel
- surface messages in Problems panel via diagnostics
- instrument command handlers, visualizer, exporters and import handling
- centralize helpers in `logger.ts`

## Testing
- `npm run compile`
- `npm test` *(fails: 25 errors, 33 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6846c3acc5b083288649f7ab17c2920d