### PR TITLE
Add detailed diagnostics logging

### DIFF
--- a/src/commands/visualize.ts
+++ b/src/commands/visualize.ts
@@ -11,6 +11,11 @@ let panel: vscode.WebviewPanel | undefined;
 
 export async function visualize(context: vscode.ExtensionContext, fileUri?: vscode.Uri) {
     logger.info(`visualize command started with ${fileUri?.fsPath ?? 'active editor'}`);
+    const targetUri = fileUri ?? vscode.window.activeTextEditor?.document.uri;
+    if (targetUri) {
+        clearDiagnostics(targetUri);
+        reportDiagnostic(targetUri, 'Visualization command initiated', 0, 0, vscode.DiagnosticSeverity.Information);
+    }
     let document: vscode.TextDocument;
     let code: string;
 
@@ -20,6 +25,7 @@ export async function visualize(context: vscode.ExtensionContext, fileUri?: vsco
             const fileData = await vscode.workspace.fs.readFile(fileUri);
             code = Buffer.from(fileData).toString('utf8');
             document = await vscode.workspace.openTextDocument(fileUri);
+            reportDiagnostic(document.uri, 'File content loaded', 0, 0, vscode.DiagnosticSeverity.Information);
         } catch (error: any) {
             const msg = `Could not read file: ${error.message || String(error)}`;
             vscode.window.showErrorMessage(msg);
@@ -37,6 +43,7 @@ export async function visualize(context: vscode.ExtensionContext, fileUri?: vsco
         }
         document = editor.document;
         code = document.getText();
+        reportDiagnostic(document.uri, 'Using active editor content', 0, 0, vscode.DiagnosticSeverity.Information);
     }
 
     let originalGraph: ContractGraph | null = null;
@@ -44,9 +51,10 @@ export async function visualize(context: vscode.ExtensionContext, fileUri?: vsco
     try {
         const language = detectLanguage(document.fileName);
         logger.debug(`Detected language ${language}`);
+        reportDiagnostic(document.uri, `Detected language ${language}`, 0, 0, vscode.DiagnosticSeverity.Information);
         originalGraph = await parseContractByLanguage(code, language, document.uri);
         logger.debug('Parsed contract to graph');
-        clearDiagnostics(document.uri);
+        reportDiagnostic(document.uri, 'Contract parsed', 0, 0, vscode.DiagnosticSeverity.Information);
 
         if (panel) {
             panel.dispose();
@@ -54,6 +62,7 @@ export async function visualize(context: vscode.ExtensionContext, fileUri?: vsco
 
         panel = createVisualizationPanel(context, originalGraph, getFunctionTypeFilters(language));
         logger.debug('Visualization panel created');
+        reportDiagnostic(document.uri, 'Visualization panel created', 0, 0, vscode.DiagnosticSeverity.Information);
 
         panel.onDidDispose(() => {
             panel = undefined;
@@ -71,10 +80,14 @@ export async function visualize(context: vscode.ExtensionContext, fileUri?: vsco
                     const nameFilter = message.nameFilter ? message.nameFilter.trim().toLowerCase() : '';
                     logger.debug(`Applying filters types=${selectedTypes.join(',')} name=${nameFilter}`);
                     applyFilters(panel!, originalGraph, selectedTypes, nameFilter);
+                    reportDiagnostic(document.uri, `Filters applied types=${selectedTypes.join(',')} name=${nameFilter}`,
+                        0, 0, vscode.DiagnosticSeverity.Information);
 
                 } else {
                     logger.debug(`Handling export command ${message.command}`);
                     await handleExport(panel!, message, context);
+                    reportDiagnostic(document.uri, `Export command ${message.command}`,
+                        0, 0, vscode.DiagnosticSeverity.Information);
                 }
             },
             undefined,
@@ -83,7 +96,9 @@ export async function visualize(context: vscode.ExtensionContext, fileUri?: vsco
 
         panel!.reveal(vscode.ViewColumn.Beside);
         logger.debug('Visualization panel revealed');
+        reportDiagnostic(document.uri, 'Visualization panel revealed', 0, 0, vscode.DiagnosticSeverity.Information);
         logger.info('visualize command completed successfully');
+        reportDiagnostic(document.uri, 'Visualization completed', 0, 0, vscode.DiagnosticSeverity.Information);
     } catch (error: any) {
         logger.error('Error visualizing contract', error);
         const msg = error.message || String(error);

--- a/src/commands/visualizeProject.ts
+++ b/src/commands/visualizeProject.ts
@@ -5,11 +5,17 @@ import { ContractGraph } from '../types/graph';
 import { detectLanguage, parseContractWithImports, getFunctionTypeFilters } from '../parser/parserUtils';
 import logger from '../logging/logger';
 import { applyFilters } from './filterUtils';
+import { reportDiagnostic, clearDiagnostics } from '../logging/diagnostics';
 
 let panel: vscode.WebviewPanel | undefined;
 
 export async function visualizeProject(context: vscode.ExtensionContext, fileUri?: vscode.Uri) {
     logger.info(`visualizeProject command started with ${fileUri?.fsPath ?? 'active editor'}`);
+    const targetUri = fileUri ?? vscode.window.activeTextEditor?.document.uri;
+    if (targetUri) {
+        clearDiagnostics(targetUri);
+        reportDiagnostic(targetUri, 'Project visualization command initiated', 0, 0, vscode.DiagnosticSeverity.Information);
+    }
     let document: vscode.TextDocument;
     let code: string;
     let filePath: string;
@@ -21,6 +27,7 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
             code = Buffer.from(fileData).toString('utf8');
             filePath = fileUri.fsPath;
             document = await vscode.workspace.openTextDocument(fileUri);
+            reportDiagnostic(document.uri, 'File content loaded', 0, 0, vscode.DiagnosticSeverity.Information);
         } catch (error: any) {
             vscode.window.showErrorMessage(`Could not read file: ${error.message || String(error)}`);
             logger.error('Failed to read file', error);
@@ -36,6 +43,7 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
         document = editor.document;
         code = document.getText();
         filePath = document.uri.fsPath;
+        reportDiagnostic(document.uri, 'Using active editor content', 0, 0, vscode.DiagnosticSeverity.Information);
     }
 
     try {
@@ -47,10 +55,12 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
             progress.report({ increment: 20, message: 'Detecting language...' });
             const language = detectLanguage(filePath);
             logger.debug(`Detected language ${language}`);
+            reportDiagnostic(document.uri, `Detected language ${language}`, 0, 0, vscode.DiagnosticSeverity.Information);
 
             progress.report({ increment: 30, message: 'Processing imports...' });
             let originalGraph = await parseContractWithImports(code, filePath, language);
             logger.debug('Parsed contract with imports');
+            reportDiagnostic(document.uri, 'Contract with imports parsed', 0, 0, vscode.DiagnosticSeverity.Information);
 
             progress.report({ increment: 30, message: 'Generating visualization...' });
             if (panel) {
@@ -59,6 +69,7 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
 
             panel = createVisualizationPanel(context, originalGraph, getFunctionTypeFilters(language), 'Contract Project Visualization');
             logger.debug('Visualization panel created');
+            reportDiagnostic(document.uri, 'Visualization panel created', 0, 0, vscode.DiagnosticSeverity.Information);
 
             panel.onDidDispose(() => {
                 panel = undefined;
@@ -71,9 +82,13 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
                         const nameFilter = message.nameFilter ? message.nameFilter.trim().toLowerCase() : '';
                         logger.debug(`Applying filters types=${selectedTypes.join(',')} name=${nameFilter}`);
                         applyFilters(panel!, originalGraph, selectedTypes, nameFilter);
+                        reportDiagnostic(document.uri, `Filters applied types=${selectedTypes.join(',')} name=${nameFilter}`,
+                            0, 0, vscode.DiagnosticSeverity.Information);
                     } else {
                         logger.debug(`Handling export command ${message.command}`);
                         await handleExport(panel!, message, context);
+                        reportDiagnostic(document.uri, `Export command ${message.command}`,
+                            0, 0, vscode.DiagnosticSeverity.Information);
                     }
                 },
                 undefined,
@@ -83,7 +98,9 @@ export async function visualizeProject(context: vscode.ExtensionContext, fileUri
             progress.report({ increment: 20, message: 'Opening visualization...' });
             panel!.reveal(vscode.ViewColumn.Beside);
             logger.debug('Visualization panel revealed');
+            reportDiagnostic(document.uri, 'Visualization panel revealed', 0, 0, vscode.DiagnosticSeverity.Information);
             logger.info('visualizeProject command completed successfully');
+            reportDiagnostic(document.uri, 'Project visualization completed', 0, 0, vscode.DiagnosticSeverity.Information);
         });
     } catch (error: any) {
         logger.error('Error visualizing contract project', error);

--- a/src/logging/diagnostics.ts
+++ b/src/logging/diagnostics.ts
@@ -2,10 +2,17 @@ import * as vscode from 'vscode';
 
 export const diagnosticCollection = vscode.languages.createDiagnosticCollection('ton-graph');
 
-export function reportDiagnostic(uri: vscode.Uri, message: string, line = 0, column = 0): void {
+export function reportDiagnostic(
+  uri: vscode.Uri,
+  message: string,
+  line = 0,
+  column = 0,
+  severity: vscode.DiagnosticSeverity = vscode.DiagnosticSeverity.Error
+): void {
   const range = new vscode.Range(line, column, line, column + 1);
-  const diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
-  diagnosticCollection.set(uri, [diagnostic]);
+  const diagnostic = new vscode.Diagnostic(range, message, severity);
+  const existing = diagnosticCollection.get(uri) || [];
+  diagnosticCollection.set(uri, [...existing, diagnostic]);
 }
 
 export function clearDiagnostics(uri: vscode.Uri): void {


### PR DESCRIPTION
## Summary
- enhance diagnostic reporting to accumulate entries and handle severity
- log all major command steps to Problems view

## Testing
- `npm install` *(fails: git dep preparation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6846c85a0f448328bd9329fb7c6c4f50